### PR TITLE
Add Admonition for Current Home of Cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cookiecutter for Nautobot Apps.
 
-**NOTICE ⚠️:** This recipe is intended for 1.5.2+/2.0 of Nautobot. It will not be compatible with previous releases of Nautobot that do not have support for [our Apps API](https://docs.nautobot.com/projects/core/en/stable/release-notes/version-1.5/?h=api+app#nautobot-apps-api-2723) and has not been ratified. Until then, please check out [the existing cookie in the NTC org](https://github.com/networktocode-llc/cookiecutter-ntc/tree/main/nautobot-plugin).
+**NOTICE ⚠️:** This recipe requires Nautobot 1.5.2+. It will not be compatible with previous releases of Nautobot that do not have support for [our Apps API](https://docs.nautobot.com/projects/core/en/stable/release-notes/version-1.5/#nautobot-apps-api-2723) and has not been ratified. Until then, please check out [the existing cookie in the NTC org](https://github.com/networktocode-llc/cookiecutter-ntc/tree/main/nautobot-plugin). This will be the future home of the Nautobot App Cookie for the purpose of 2.0 migration, open-sourcing, and book.
 
 ## Introduction
 


### PR DESCRIPTION
We need to:
- Mint a 1.0 of the 1.4+ supporting recipe in the NTC org
- Ensure all deltas between that recipe and this one are addressed (MySQL fixes, etc)
- Mint this as the 1.1 of the cookie recipe (moving minimum to 1.5.2+)
- Update/redirect users who stumble upon the NTC org recipe who can support 1.5.2+ to here

Until then we don't want anyone landing here expecting to find a 1.4 supporting cookie.