### PR TITLE
Removes period from end of line to ease in copy/paste.

### DIFF
--- a/nautobot-app/hooks/post_gen_project.py
+++ b/nautobot-app/hooks/post_gen_project.py
@@ -6,7 +6,7 @@ _PROJECT_PATH = Path.cwd()
 _ADDONS_PATH = _PROJECT_PATH / "{{ cookiecutter.app_name }}"
 
 _CONGRATS = f"""
-Congratulations! Your cookie has now been baked. It is located at {_PROJECT_PATH}.
+Congratulations! Your cookie has now been baked. It is located at {_PROJECT_PATH}
 
 ⚠️⚠️ Before you start using your cookie you must run the following commands inside your cookie:
 


### PR DESCRIPTION
The output of this is incorrect, as you are not in the directory.

```
⚠️⚠️ Before you start using your cookie you must run the following commands inside your cookie:

* poetry lock
* cp development/creds.example.env development/creds.env
* poetry shell
* invoke makemigrations
* black . # this will ensure all python files are formatted correctly, may require `sudo chown -R <my local username> ./` as migrations may be owned by root
* ```
This should likely have a `cd  {{ directory_name }}` in it, but this is at least a start that you can copy and paste the output of where the cookie was sent to.

Note that when you double click for copy/paste ease, then the period is included that is being removed.