### PR TITLE
Fix ruff exclude

### DIFF
--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -116,9 +116,6 @@ supported_nautobot_versions = [
 [tool.ruff]
 line-length = 120
 target-version = "py38"
-exclude = [
-    "migrations",
-]
 
 [tool.ruff.lint]
 select = [
@@ -141,6 +138,22 @@ ignore = [
 
     # Produces a lot of issues in the current codebase.
     "D401",  # First line of docstring should be in imperative mood
+    "D407",  # Missing dashed underline after section
+    "D416",  # Section name ends in colon
+]
+
+[tool.ruff.per-file-ignores]
+"{{ cookiecutter.app_name }}/migrations/*" = [
+    "D1",  # pydocstyle
+    "D2",  # pydocstyle
+    "D3",  # pydocstyle
+    "D4",  # pydocstyle
+]
+"{{ cookiecutter.app_name }}/tests/*" = [
+    "D1",  # pydocstyle
+    "D2",  # pydocstyle
+    "D3",  # pydocstyle
+    "D4",  # pydocstyle
 ]
 
 [build-system]

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -142,6 +142,9 @@ ignore = [
     "D416",  # Section name ends in colon
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.per-file-ignores]
 "{{ cookiecutter.app_name }}/migrations/*" = [
     "D1",  # pydocstyle

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -119,10 +119,7 @@ target-version = "py38"
 
 [tool.ruff.lint]
 select = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 ignore = [
     # warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible.
@@ -147,16 +144,10 @@ convention = "google"
 
 [tool.ruff.per-file-ignores]
 "{{ cookiecutter.app_name }}/migrations/*" = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 "{{ cookiecutter.app_name }}/tests/*" = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 
 [build-system]

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -116,10 +116,7 @@ target-version = "py38"
 
 [tool.ruff.lint]
 select = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 ignore = [
     # warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible.
@@ -144,16 +141,10 @@ convention = "google"
 
 [tool.ruff.per-file-ignores]
 "{{ cookiecutter.app_name }}/migrations/*" = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 "{{ cookiecutter.app_name }}/tests/*" = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 
 [build-system]

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -139,6 +139,9 @@ ignore = [
     "D416",  # Section name ends in colon
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.per-file-ignores]
 "{{ cookiecutter.app_name }}/migrations/*" = [
     "D1",  # pydocstyle

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -113,9 +113,6 @@ supported_nautobot_versions = [
 [tool.ruff]
 line-length = 120
 target-version = "py38"
-exclude = [
-    "migrations",
-]
 
 [tool.ruff.lint]
 select = [
@@ -138,6 +135,22 @@ ignore = [
 
     # Produces a lot of issues in the current codebase.
     "D401",  # First line of docstring should be in imperative mood
+    "D407",  # Missing dashed underline after section
+    "D416",  # Section name ends in colon
+]
+
+[tool.ruff.per-file-ignores]
+"{{ cookiecutter.app_name }}/migrations/*" = [
+    "D1",  # pydocstyle
+    "D2",  # pydocstyle
+    "D3",  # pydocstyle
+    "D4",  # pydocstyle
+]
+"{{ cookiecutter.app_name }}/tests/*" = [
+    "D1",  # pydocstyle
+    "D2",  # pydocstyle
+    "D3",  # pydocstyle
+    "D4",  # pydocstyle
 ]
 
 [build-system]

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -138,6 +138,9 @@ ignore = [
     "D416",  # Section name ends in colon
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.per-file-ignores]
 "{{ cookiecutter.app_name }}/migrations/*" = [
     "D1",  # pydocstyle

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -112,9 +112,6 @@ supported_nautobot_versions = [
 [tool.ruff]
 line-length = 120
 target-version = "py38"
-exclude = [
-    "migrations",
-]
 
 [tool.ruff.lint]
 select = [
@@ -137,6 +134,22 @@ ignore = [
 
     # Produces a lot of issues in the current codebase.
     "D401",  # First line of docstring should be in imperative mood
+    "D407",  # Missing dashed underline after section
+    "D416",  # Section name ends in colon
+]
+
+[tool.ruff.per-file-ignores]
+"{{ cookiecutter.app_name }}/migrations/*" = [
+    "D1",  # pydocstyle
+    "D2",  # pydocstyle
+    "D3",  # pydocstyle
+    "D4",  # pydocstyle
+]
+"{{ cookiecutter.app_name }}/tests/*" = [
+    "D1",  # pydocstyle
+    "D2",  # pydocstyle
+    "D3",  # pydocstyle
+    "D4",  # pydocstyle
 ]
 
 [build-system]

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -115,10 +115,7 @@ target-version = "py38"
 
 [tool.ruff.lint]
 select = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 ignore = [
     # warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible.
@@ -143,16 +140,10 @@ convention = "google"
 
 [tool.ruff.per-file-ignores]
 "{{ cookiecutter.app_name }}/migrations/*" = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 "{{ cookiecutter.app_name }}/tests/*" = [
-    "D1",  # pydocstyle
-    "D2",  # pydocstyle
-    "D3",  # pydocstyle
-    "D4",  # pydocstyle
+    "D",  # pydocstyle
 ]
 
 [build-system]


### PR DESCRIPTION
# Closes: NaN

## What's Changed

- Fixed ruff excludes to use per-file excludes instead of global excludes.
- Align ruff with previous pydocstyle checks.
