### PR TITLE
Fix #66 invoke commands for media file backup/restore

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -540,7 +540,11 @@ def import_db(context, db_name="", input_file="dump.sql"):
 )
 def import_media(context, input_file="media.tgz"):
     """Start Nautobot containers and restore the media files into `nautobot` container."""
-    start(context, "nautobot")
+    # Check if nautobot is running, no need to start another nautobot container to run a command
+    docker_compose_status = "ps --services --filter status=running"
+    results = docker_compose(context, docker_compose_status, hide="out")
+    if "nautobot" not in results.stdout:
+        start(context, "nautobot")
     _await_healthy_service(context, "nautobot")
     command = ["exec -- nautobot sh -c '"]
     command += [ "tar", "-xzf", "-", "-C", "/" ]
@@ -613,7 +617,11 @@ def backup_db(context, db_name="", output_file="dump.sql", readable=True):
 )
 def backup_media(context, media_dir="/opt/nautobot/media", output_file="media.tgz"):
     """Dump all media files into `output_file` file from `nautobot` container."""
-    start(context, "nautobot")
+    # Check if nautobot is running, no need to start another nautobot container to run a command
+    docker_compose_status = "ps --services --filter status=running"
+    results = docker_compose(context, docker_compose_status, hide="out")
+    if "nautobot" not in results.stdout:
+        start(context, "nautobot")
     _await_healthy_service(context, "nautobot")
 
     command = ["exec -- db sh -c '"]

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -624,7 +624,7 @@ def backup_media(context, media_dir="/opt/nautobot/media", output_file="media.tg
         start(context, "nautobot")
     _await_healthy_service(context, "nautobot")
 
-    command = ["exec -- db sh -c '"]
+    command = ["exec -- nautobot sh -c '"]
     command += [ "tar", "-czf", "-", media_dir ]
     command += [
         "'",

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -563,7 +563,11 @@ def import_media(context, input_file="media.tgz"):
 )
 def backup_db(context, db_name="", output_file="dump.sql", readable=True):
     """Dump database into `output_file` file from `db` container."""
-    start(context, "db")
+    # Check if db is running, no need to start another db container to run a command
+    docker_compose_status = "ps --services --filter status=running"
+    results = docker_compose(context, docker_compose_status, hide="out")
+    if "db" not in results.stdout:
+        start(context, "db")
     _await_healthy_service(context, "db")
 
     command = ["exec -- db sh -c '"]


### PR DESCRIPTION
Added the commands:

- **invoke backup-media**:  to backup all media files in `media.tgz`

     ```
      help={
          "media-dir": "Media directory to backup (default: `/opt/nautobot/media`)",
          "output-file": "Output file, overwrite if exists (default: `media.tgz`)",
       }
     ```

- **invoke import-media**:  to import the `media.tgz` file and restore to it's location (media-dir at backup time)

    ```
    help={
        "input-file": "Tar file containing media files from backup. This can be generated using `invoke backup-media` (default: `media.tgz`).",
    }
    ``` 

