### PR TITLE
Fix invoke cli command

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -159,7 +159,7 @@ def run_command(context, command, **kwargs):
         if "nautobot" in results.stdout:
             compose_command = f"exec nautobot {command}"
         else:
-            compose_command = f"run --rm --entrypoint '{command}' nautobot"
+            compose_command = f"run --rm --entrypoint '' nautobot '{command}'"
 
         pty = kwargs.pop("pty", True)
 


### PR DESCRIPTION
There is a bug where if you run `invoke cli` before the containers are started you will get an error and not get the expected bash prompt. This tweak ensures that the nautobot container is started before issuing the bash command.