### PR TITLE
Incorrect ref for url

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/templates/{{ cookiecutter.app_name }}/{{ cookiecutter.model_class_name | lower }}_retrieve.html
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/templates/{{ cookiecutter.app_name }}/{{ cookiecutter.model_class_name | lower }}_retrieve.html
@@ -5,22 +5,22 @@
 {% block content_left_page %}
     <div class="panel panel-default">
         <div class="panel-heading">
-			<strong>{% endraw %}{{ cookiecutter.model_class_name }}{% raw %}</strong>
-		</div>
-		<table class="table table-hover panel-body attr-table">
-			<tr>
-				<td>Name</td>
-				<td>
-					<a href="{{ object | hyperlinked_object }}">{{ object.name }}</a>
-				</td>
-			</tr>
-			<tr>
-				<td>Description</td>
-				<td>
-					{{ object.description|placeholder }}
-				</td>
-			</tr>
-		</table>
-	</div>
+            <strong>{% endraw %}{{ cookiecutter.model_class_name }}{% raw %}</strong>
+        </div>
+        <table class="table table-hover panel-body attr-table">
+            <tr>
+                <td>Name</td>
+                <td>
+                    {{ object.name }}
+                </td>
+            </tr>
+            <tr>
+                <td>Description</td>
+                <td>
+                    {{ object.description|placeholder }}
+                </td>
+            </tr>
+        </table>
+    </div>
 {% endblock %}
 {% endraw %}


### PR DESCRIPTION
No need to linkify name for same object on detail page. Also filter used provides the full a tag not just the path.