### PR TITLE
Dont Drift-manage Nornir

### DIFF
--- a/.github/workflows/tag-nautobot-app-v2.yml
+++ b/.github/workflows/tag-nautobot-app-v2.yml
@@ -25,7 +25,7 @@ jobs:
           - "floor-plan"
           - "golden-config"
           - "netbox-importer"
-          - "nornir"
+          # - "nornir"  # Postponed
           - "secrets-providers"
           - "ssot"
           # - "version-control"  # Disabled as not Nautobot 2.0 ready


### PR DESCRIPTION
# Closes: NaN

## What's Changed

- Removed `nornir` from the list of drift managed apps.
