### PR TITLE
Fix SSoT Jobs

### DIFF
--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/jobs.py
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/jobs.py
@@ -43,6 +43,14 @@ class {{ cookiecutter.system_of_record_camel }}DataSource(DataSource):
         self.target_adapter = nautobot.NautobotAdapter(job=self, sync=self.sync)
         self.target_adapter.load()
 
+    def run(self, dryrun, memory_profiling, debug, *args, **kwargs):  # pylint: disable=arguments-differ
+        """Perform data synchronization."""
+        self.debug = debug
+        self.dryrun = dryrun
+        self.memory_profiling = memory_profiling
+        super().run(dryrun=self.dryrun, memory_profiling=self.memory_profiling, *args, **kwargs)
+
+
 class {{ cookiecutter.system_of_record_camel }}DataTarget(DataTarget):
     """{{ cookiecutter.system_of_record }} SSoT Data Target."""
 
@@ -75,6 +83,13 @@ class {{ cookiecutter.system_of_record_camel }}DataTarget(DataTarget):
         """Load data from {{ cookiecutter.system_of_record }} into DiffSync models."""
         self.target_adapter = {{ cookiecutter.system_of_record_slug }}.{{ cookiecutter.system_of_record_camel }}Adapter(job=self, sync=self.sync)
         self.target_adapter.load()
+
+    def run(self, dryrun, memory_profiling, debug, *args, **kwargs):  # pylint: disable=arguments-differ
+        """Perform data synchronization."""
+        self.debug = debug
+        self.dryrun = dryrun
+        self.memory_profiling = memory_profiling
+        super().run(dryrun=self.dryrun, memory_profiling=self.memory_profiling, *args, **kwargs)
 
 
 jobs = [{{ cookiecutter.system_of_record_camel }}DataSource, {{ cookiecutter.system_of_record_camel }}DataTarget]

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/jobs.py
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/jobs.py
@@ -1,6 +1,6 @@
 """Jobs for {{ cookiecutter.system_of_record }} SSoT integration."""
 
-from diffsync import DiffSyncFlags
+
 from nautobot.app.jobs import BooleanVar, Job, register_jobs
 from nautobot_ssot.jobs.base import DataSource, DataTarget
 
@@ -14,12 +14,6 @@ class {{ cookiecutter.system_of_record_camel }}DataSource(DataSource, Job):
     """{{ cookiecutter.system_of_record }} SSoT Data Source."""
 
     debug = BooleanVar(description="Enable for more verbose debug logging", default=False)
-
-    def __init__(self):
-        """Initialize {{ cookiecutter.system_of_record }} Data Source."""
-        super().__init__()
-        # pylint: disable-next=unsupported-binary-operation
-        self.diffsync_flags = self.diffsync_flags | DiffSyncFlags.CONTINUE_ON_FAILURE
 
     class Meta:  # pylint: disable=too-few-public-methods
         """Meta data for {{ cookiecutter.system_of_record }}."""
@@ -54,11 +48,6 @@ class {{ cookiecutter.system_of_record_camel }}DataTarget(DataTarget, Job):
     """{{ cookiecutter.system_of_record }} SSoT Data Target."""
 
     debug = BooleanVar(description="Enable for more verbose debug logging", default=False)
-
-    def __init__(self):
-        """Initialize {{ cookiecutter.system_of_record }} Data Target."""
-        super().__init__()
-        self.diffsync_flags = int(self.diffsync_flags) | DiffSyncFlags.CONTINUE_ON_FAILURE
 
     class Meta:  # pylint: disable=too-few-public-methods
         """Meta data for {{ cookiecutter.system_of_record }}."""

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/jobs.py
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/jobs.py
@@ -1,7 +1,7 @@
 """Jobs for {{ cookiecutter.system_of_record }} SSoT integration."""
 
 
-from nautobot.app.jobs import BooleanVar, Job, register_jobs
+from nautobot.app.jobs import BooleanVar, register_jobs
 from nautobot_ssot.jobs.base import DataSource, DataTarget
 
 from {{ cookiecutter.app_name }}.diffsync.adapters import {{ cookiecutter.system_of_record_slug }}, nautobot
@@ -10,7 +10,7 @@ from {{ cookiecutter.app_name }}.diffsync.adapters import {{ cookiecutter.system
 name = "{{ cookiecutter.system_of_record }} SSoT"  # pylint: disable=invalid-name
 
 
-class {{ cookiecutter.system_of_record_camel }}DataSource(DataSource, Job):
+class {{ cookiecutter.system_of_record_camel }}DataSource(DataSource):
     """{{ cookiecutter.system_of_record }} SSoT Data Source."""
 
     debug = BooleanVar(description="Enable for more verbose debug logging", default=False)
@@ -43,8 +43,7 @@ class {{ cookiecutter.system_of_record_camel }}DataSource(DataSource, Job):
         self.target_adapter = nautobot.NautobotAdapter(job=self, sync=self.sync)
         self.target_adapter.load()
 
-
-class {{ cookiecutter.system_of_record_camel }}DataTarget(DataTarget, Job):
+class {{ cookiecutter.system_of_record_camel }}DataTarget(DataTarget):
     """{{ cookiecutter.system_of_record }} SSoT Data Target."""
 
     debug = BooleanVar(description="Enable for more verbose debug logging", default=False)


### PR DESCRIPTION
While reviewing the SSoT template I found that both of the templated Jobs were using the 1.x pattern instead of 2.x. I've corrected it so that it's using the 2.x pattern:

1. Remove Job class inheritance as no longer needed since DataSource/DataTarget both inherit from Job directly now.
2. Remove dunder init for setting DiffSyncFlags as this is already done in the base DataSource/DataTarget classes.
3. Add run() to both Jobs with the expected Job form variables. This is required so that the dryrun, debug, and memory profiling toggles function as expected.