### PR TITLE
fix: Removed default-authentication-plugin setting

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.mysql.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.mysql.yml
@@ -17,7 +17,6 @@ services:
   db:
     image: "mysql:8"
     command:
-      - "--default-authentication-plugin=mysql_native_password"
       - "--max_connections=1000"
     env_file:
       - "development.env"


### PR DESCRIPTION
MySQL 8 now complains that the `default-authentication-plugin=mysql_native_password` is not found and the container then exits. I removed this setting from my environment and the container comes up and all unit tests pass.