### PR TITLE
Replace mkdocs-version-annotations with markdown-version-annotations

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -96,7 +96,7 @@ a.autorefs-external:hover::after {
 }
 
 
-/* Customization for mkdocs-version-annotations */
+/* Customization for markdown-version-annotations */
 :root {
     /* Icon for "version-added" admonition: Material Design Icons "plus-box-outline" */
     --md-admonition-icon--version-added: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 19V5H5v14h14m0-16a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14m-8 4h2v4h4v2h-4v4h-2v-4H7v-2h4V7Z"/></svg>');

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.5.2
 mkdocs-material==9.1.15
-mkdocs-version-annotations==1.0.0
+markdown-version-annotations==1.0.1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,8 @@ extra:
       link: "https://twitter.com/networktocode"
       name: "Network to Code Twitter"
 markdown_extensions:
+  - "markdown_version_annotations":
+      admonition_tag: "???"
   - "admonition"
   - "toc":
       permalink: true
@@ -78,7 +80,6 @@ markdown_extensions:
   - "footnotes"
 plugins:
   - "search"
-  - "mkdocs-version-annotations"
 watch:
   - "README.md"
 

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -52,12 +52,12 @@ ruff = "*"
 yamllint = "*"
 toml = "*"
 Markdown = "*"
+# Render custom markdown for version added/changed/remove notes
+markdown-version-annotations = "1.0.1"
 # Rendering docs to HTML
 mkdocs = "1.5.2"
 # Material for MkDocs theme
 mkdocs-material = "9.1.15"
-# Render custom markdown for version added/changed/remove notes
-mkdocs-version-annotations = "1.0.0"
 # Automatic documentation from sources, for MkDocs
 mkdocstrings = "0.22.0"
 mkdocstrings-python = "1.5.2"

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -49,12 +49,12 @@ ruff = "*"
 yamllint = "*"
 toml = "*"
 Markdown = "*"
+# Render custom markdown for version added/changed/remove notes
+markdown-version-annotations = "1.0.1"
 # Rendering docs to HTML
 mkdocs = "1.5.2"
 # Material for MkDocs theme
 mkdocs-material = "9.1.15"
-# Render custom markdown for version added/changed/remove notes
-mkdocs-version-annotations = "1.0.0"
 # Automatic documentation from sources, for MkDocs
 mkdocstrings = "0.22.0"
 mkdocstrings-python = "1.5.2"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/assets/extra.css
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/assets/extra.css
@@ -96,7 +96,7 @@ a.autorefs-external:hover::after {
 }
 
 
-/* Customization for mkdocs-version-annotations */
+/* Customization for markdown-version-annotations */
 :root {
     /* Icon for "version-added" admonition: Material Design Icons "plus-box-outline" */
     --md-admonition-icon--version-added: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19 19V5H5v14h14m0-16a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14m-8 4h2v4h4v2h-4v4h-2v-4H7v-2h4V7Z"/></svg>');

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/requirements.txt
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==1.5.2
 mkdocs-material==9.1.15
-mkdocs-version-annotations==1.0.0
+markdown-version-annotations==1.0.1
 mkdocstrings-python==1.5.2
 mkdocstrings==0.22.0

--- a/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
@@ -72,6 +72,8 @@ extra:
       link: "https://twitter.com/networktocode"
       name: "Network to Code Twitter"
 markdown_extensions:
+  - "markdown_version_annotations":
+      admonition_tag: "???"
   - "admonition"
   - "toc":
       permalink: true
@@ -89,7 +91,6 @@ markdown_extensions:
   - "footnotes"
 plugins:
   - "search"
-  - "mkdocs-version-annotations"
   - "mkdocstrings":
       default_handler: "python"
       handlers:

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -48,12 +48,12 @@ ruff = "*"
 yamllint = "*"
 toml = "*"
 Markdown = "*"
+# Render custom markdown for version added/changed/remove notes
+markdown-version-annotations = "1.0.1"
 # Rendering docs to HTML
 mkdocs = "1.5.2"
 # Material for MkDocs theme
 mkdocs-material = "9.1.15"
-# Render custom markdown for version added/changed/remove notes
-mkdocs-version-annotations = "1.0.0"
 # Automatic documentation from sources, for MkDocs
 mkdocstrings = "0.22.0"
 mkdocstrings-python = "1.5.2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -562,6 +562,20 @@ rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
+name = "markdown-version-annotations"
+version = "1.0.1"
+description = "Markdown plugin to add custom admonitions for documenting version differences"
+optional = false
+python-versions = "<4.0,>=3.7"
+files = [
+    {file = "markdown_version_annotations-1.0.1-py3-none-any.whl", hash = "sha256:6df0b2ac08bab906c8baa425f59fc0fe342fbe8b3917c144fb75914266b33200"},
+    {file = "markdown_version_annotations-1.0.1.tar.gz", hash = "sha256:620aade507ef175ccfb2059db152a34c6a1d2add28c2be16ea4de38d742e6132"},
+]
+
+[package.dependencies]
+markdown = ">=3.3.7,<4.0.0"
+
+[[package]]
 name = "markupsafe"
 version = "2.1.3"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -730,17 +744,6 @@ python-versions = ">=3.8"
 files = [
     {file = "mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31"},
     {file = "mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443"},
-]
-
-[[package]]
-name = "mkdocs-version-annotations"
-version = "1.0.0"
-description = "MkDocs plugin to add custom admonitions for documenting version differences"
-optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "mkdocs-version-annotations-1.0.0.tar.gz", hash = "sha256:6786024b37d27b330fda240b76ebec8e7ce48bd5a9d7a66e99804559d088dffa"},
-    {file = "mkdocs_version_annotations-1.0.0-py3-none-any.whl", hash = "sha256:385004eb4a7530dd87a227e08cd907ce7a8fe21fdf297720a4149c511bcf05f5"},
 ]
 
 [[package]]
@@ -1371,4 +1374,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "4831e88c2875b222dc4de91f4afc367052d2a709b32841e51d4262856a68a2d1"
+content-hash = "a2590e330296a2273d1ad5430d1d5c0806fdc2d4a5c552be6972767d8ff4ac9c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,12 @@ pytest = "*"
 pytest-cookies = "*"
 yamllint = "*"
 Markdown = "*"
+# Render custom markdown for version added/changed/remove notes
+markdown-version-annotations = "1.0.1"
 # Rendering docs to HTML
 mkdocs = "1.5.2"
 # Material for MkDocs theme
 mkdocs-material = "9.1.15"
-# Render custom markdown for version added/changed/remove notes
-mkdocs-version-annotations = "1.0.0"
 # Automatic documentation from sources, for MkDocs
 mkdocstrings = "0.22.0"
 mkdocstrings-python = "1.5.2"


### PR DESCRIPTION
`mkdocs-version-annotations` has been reimplemented as a Markdown extension rather than a mkdocs-specific plugin, and re-released as `markdown-version-annotations` with some new features. It's a drop-in replacement from a docs authorship perspective, but does need to be configured in `mkdocs.yml` as a Markdown extension rather than a mkdocs plugin.

This also takes advantage of the new `admonition_tag` config option to make it so that version notes in the docs default to collapsed-but-expandable rather than always-expanded.