### PR TITLE
Fix comments in flake8 file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,8 @@
 [flake8]
 ignore =
-    E203,  # Black disagrees with this rule, as does PEP 8; Black wins
-    E501,  # Line length is enforced by Black, so flake8 doesn't need to check it
-    W503  # Black disagrees with this rule, as does PEP 8; Black wins
+    # Black disagrees with this rule, as does PEP 8; Black wins
+    E203,
+    # Line length is enforced by Black, so flake8 doesn't need to check it
+    E501,
+    # Black disagrees with this rule, as does PEP 8; Black wins
+    W503

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.flake8
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.flake8
@@ -1,7 +1,9 @@
 [flake8]
 ignore =
-  E501,  # Line length is enforced by Black, so flake8 doesn't need to check it
-  W503   # Black disagrees with this rule, as does PEP 8; Black wins
+  # Line length is enforced by Black, so flake8 doesn't need to check it
+  E501,
+  # Black disagrees with this rule, as does PEP 8; Black wins
+  W503
 exclude = 
   migrations,
   __pycache__,


### PR DESCRIPTION

As per https://flake8.pycqa.org/en/latest/user/configuration.html :

```
Note

Following the recommended settings for [Python’s configparser](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour), Flake8 does not support inline comments for any of the keys. So while this is fine:
```