### PR TITLE
Update to match other .dockerignore

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/.dockerignore
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.dockerignore
@@ -19,7 +19,6 @@ FAQ.md
 .git/
 .gitignore
 .github
-tasks.py
 LICENSE
 **/*.log
 **/.vscode/


### PR DESCRIPTION
CLOSES: #105 
Removes duplicate tasks.py, but leaves the one that is in the same location as the other cookiecutter templates.