### PR TITLE
LTM 1.6 updates

### DIFF
--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -51,14 +51,15 @@ yamllint = "*"
 toml = "*"
 Markdown = "*"
 # Rendering docs to HTML
-mkdocs = "1.5.2"
+mkdocs = "1.5.3"
 # Material for MkDocs theme
-mkdocs-material = "9.1.15"
+mkdocs-material = "9.1.18"
 # Render custom markdown for version added/changed/remove notes
-mkdocs-version-annotations = "1.0.0"
+markdown-version-annotations = "1.0.1"
 # Automatic documentation from sources, for MkDocs
 mkdocstrings = "0.22.0"
-mkdocstrings-python = "1.5.2"
+mkdocstrings-python = "1.2.0"
+griffe = "0.31.0"
 
 [tool.black]
 line-length = 120

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on: # yamllint disable-line rule:truthy rule:comments
   pull_request: ~
 
 env:
-  PLUGIN_NAME: "{{cookiecutter.project_slug}}"
+  PLUGIN_NAME: "{{cookiecutter.plugin_slug}}"
 
 jobs:
   black:
@@ -138,7 +138,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.11"]
-        nautobot-version: ["{{cookiecutter.min_nautobot_version}}"]
+        nautobot-version: ["1.6.0"]
     env:
       INVOKE_{{cookiecutter.plugin_name.upper()}}_PYTHON_VER: "{% raw %}${{ matrix.python-version }}{% endraw %}"
       INVOKE_{{cookiecutter.plugin_name.upper()}}_NAUTOBOT_VER: "{% raw %}${{ matrix.nautobot-version }}{% endraw %}"
@@ -177,14 +177,14 @@ jobs:
       matrix:
         python-version: ["3.8", "3.11"]
         db-backend: ["postgresql"]
-        nautobot-version: ["stable"]
+        nautobot-version: ["1.6"]
         include:
           - python-version: "3.11"
             db-backend: "postgresql"
             nautobot-version: "{{cookiecutter.min_nautobot_version}}"
           - python-version: "3.11"
             db-backend: "mysql"
-            nautobot-version: "stable"
+            nautobot-version: "1.6"
     runs-on: "ubuntu-22.04"
     env:
       INVOKE_{{cookiecutter.plugin_name.upper()}}_PYTHON_VER: "{% raw %}${{ matrix.python-version }}{% endraw %}"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.11"]
-        nautobot-version: ["1.6.0"]
+        nautobot-version: ["1.6"]
     env:
       INVOKE_{{cookiecutter.plugin_name.upper()}}_PYTHON_VER: "{% raw %}${{ matrix.python-version }}{% endraw %}"
       INVOKE_{{cookiecutter.plugin_name.upper()}}_NAUTOBOT_VER: "{% raw %}${{ matrix.nautobot-version }}{% endraw %}"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on: # yamllint disable-line rule:truthy rule:comments
   pull_request: ~
 
 env:
-  PLUGIN_NAME: "{{cookiecutter.plugin_slug}}"
+  PLUGIN_NAME: "{{ cookiecutter.plugin_slug }}"
 
 jobs:
   black:

--- a/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.base.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.base.yml
@@ -13,7 +13,6 @@ x-nautobot-base: &nautobot-base
     - "creds.env"
   tty: true
 
-version: "3.8"
 services:
   nautobot:
     depends_on:

--- a/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.dev.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.dev.yml
@@ -3,7 +3,6 @@
 # any override will need to include these volumes to use them.
 # see:  https://github.com/docker/compose/issues/3729
 ---
-version: "3.8"
 services:
   nautobot:
     command: "nautobot-server runserver 0.0.0.0:8080"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.mysql.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.mysql.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 services:
   nautobot:
     environment:
@@ -19,7 +17,6 @@ services:
   db:
     image: "mysql:8"
     command:
-      - "--default-authentication-plugin=mysql_native_password"
       - "--max_connections=1000"
     env_file:
       - "development.env"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.postgres.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.postgres.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 services:
   nautobot:
     environment:

--- a/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.redis.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/development/docker-compose.redis.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.8"
 services:
   redis:
     image: "redis:6-alpine"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/dev_environment.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/dev_environment.md
@@ -31,7 +31,7 @@ This project is managed by [Python Poetry](https://python-poetry.org/) and has a
 
 1. Install Poetry, see the [Poetry documentation](https://python-poetry.org/docs/#installation) for your operating system.
 2. Install Docker, see the [Docker documentation](https://docs.docker.com/get-docker/) for your operating system.
-3. Install Docker-compose, see the [Docker-compose documentation](https://github.com/docker/compose) for your operation system.
+3. Install Docker Compose v2, see the [Docker Compose documentation](https://github.com/docker/compose) for your operation system.
 
 Once you have Poetry and Docker installed you can run the following commands (in the root of the repository) to install all other development dependencies in an isolated Python virtual environment:
 
@@ -190,7 +190,7 @@ Next, you need to start up your Docker containers.
 ```bash
 ➜ invoke start
 Starting Nautobot in detached mode...
-Running docker-compose command "up --detach"
+Running docker compose command "up --detach"
 Creating network "{{ cookiecutter.plugin_name }}_default" with the default driver
 Creating volume "{{ cookiecutter.plugin_name }}_postgres_data" with default driver
 Creating {{ cookiecutter.plugin_name }}_redis_1 ...
@@ -241,8 +241,8 @@ If you need to create additional superusers, run the follow commands.
 
 ```bash
 ➜ invoke createsuperuser
-Running docker-compose command "ps --services --filter status=running"
-Running docker-compose command "exec nautobot nautobot-server createsuperuser --username admin"
+Running docker compose command "ps --services --filter status=running"
+Running docker compose command "exec nautobot nautobot-server createsuperuser --username admin"
 Error: That username is already taken.
 Username: ntc
 Email address: ntc@networktocode.com
@@ -258,7 +258,7 @@ The last command to know for now is `invoke stop`.
 ```bash
 ➜ invoke stop
 Stopping Nautobot...
-Running docker-compose command "down"
+Running docker compose command "down"
 Stopping {{ cookiecutter.plugin_name }}_worker_1   ...
 Stopping {{ cookiecutter.plugin_name }}_nautobot_1 ...
 Stopping {{ cookiecutter.plugin_name }}_docs_1     ...

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/requirements.txt
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/requirements.txt
@@ -1,5 +1,6 @@
-mkdocs==1.5.2
-mkdocs-material==9.1.15
-mkdocs-version-annotations==1.0.0
-mkdocstrings-python==1.5.2
-mkdocstrings==0.22.0
+mkdocs==1.6.0
+mkdocs-material==9.5.32
+markdown-version-annotations==1.0.1
+griffe==1.1.1
+mkdocstrings-python==1.10.8
+mkdocstrings==0.25.2

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/requirements.txt
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs==1.6.0
-mkdocs-material==9.5.32
+mkdocs==1.5.3
+mkdocs-material==9.1.18
 markdown-version-annotations==1.0.1
-griffe==1.1.1
-mkdocstrings-python==1.10.8
-mkdocstrings==0.25.2
+griffe==0.31.0
+mkdocstrings-python==1.2.0
+mkdocstrings==0.22.0

--- a/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
@@ -1,6 +1,6 @@
 ---
 dev_addr: "127.0.0.1:8001"
-edit_uri: "edit/main/{{cookiecutter.project_slug}}/docs"
+edit_uri: "edit/main/docs"
 site_dir: "{{cookiecutter.plugin_name}}/static/{{cookiecutter.plugin_name}}/docs"
 site_name: "{{cookiecutter.verbose_name}} Documentation"
 site_url: "{{cookiecutter.docs_app_url}}/"
@@ -72,6 +72,8 @@ extra:
       link: "https://twitter.com/networktocode"
       name: "Network to Code Twitter"
 markdown_extensions:
+  - "markdown_version_annotations":
+      admonition_tag: "???"
   - "admonition"
   - "toc":
       permalink: true
@@ -85,7 +87,6 @@ markdown_extensions:
   - "footnotes"
 plugins:
   - "search"
-  - "mkdocs-version-annotations"
   - "mkdocstrings":
       default_handler: "python"
       handlers:

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -45,19 +45,20 @@ ipython = "*"
 pydocstyle = "*"
 pylint = "*"
 pylint-django = "*"
-pylint-nautobot = "*"
+pylint-nautobot = "^0.3.1"
 yamllint = "*"
 toml = "*"
 Markdown = "*"
 # Rendering docs to HTML
-mkdocs = "1.5.2"
+mkdocs = "1.6.0"
 # Material for MkDocs theme
-mkdocs-material = "9.1.15"
+mkdocs-material = "9.5.32"
 # Render custom markdown for version added/changed/remove notes
-mkdocs-version-annotations = "1.0.0"
+rkdown-version-annotations = "1.0.1"
 # Automatic documentation from sources, for MkDocs
-mkdocstrings = "0.22.0"
-mkdocstrings-python = "1.5.2"
+mkdocstrings = "0.25.2"
+mkdocstrings-python = "1.10.8"
+griffe = "1.1.1"
 
 [tool.poetry.extras]
 all = [

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -54,7 +54,7 @@ mkdocs = "1.6.0"
 # Material for MkDocs theme
 mkdocs-material = "9.5.32"
 # Render custom markdown for version added/changed/remove notes
-rkdown-version-annotations = "1.0.1"
+markdown-version-annotations = "1.0.1"
 # Automatic documentation from sources, for MkDocs
 mkdocstrings = "0.25.2"
 mkdocstrings-python = "1.10.8"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -50,15 +50,15 @@ yamllint = "*"
 toml = "*"
 Markdown = "*"
 # Rendering docs to HTML
-mkdocs = "1.6.0"
+mkdocs = "1.5.3"
 # Material for MkDocs theme
-mkdocs-material = "9.5.32"
+mkdocs-material = "9.1.18"
 # Render custom markdown for version added/changed/remove notes
 markdown-version-annotations = "1.0.1"
 # Automatic documentation from sources, for MkDocs
-mkdocstrings = "0.25.2"
-mkdocstrings-python = "1.10.8"
-griffe = "1.1.1"
+mkdocstrings = "0.22.0"
+mkdocstrings-python = "1.2.0"
+griffe = "0.31.0"
 
 [tool.poetry.extras]
 all = [


### PR DESCRIPTION
This adds the fix for docs, backported from 2.3.1. This also fixes the CI so that it runs with Nautobot 1.6 instead of 2.3.x (Stable). Changed CI minimum version to hardcoded 1.6.0 as that is all that the LTM is meant to support, so we don't need to worry about trying to test anything older.