### PR TITLE
`repo_token` is not needed, GH provides a token

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -222,7 +222,6 @@ jobs:
       - name: "Upload binaries to release"
         uses: "svenstaro/upload-release-action@v2"
         with:
-          repo_token: "{% raw %}${{ secrets.NTC_GITHUB_TOKEN }}{% endraw %}"  # use GH_NAUTOBOT_BOT_TOKEN for Nautobot Org repos.
           file: "dist/*"
           tag: "{% raw %}${{ github.ref }}{% endraw %}"
           overwrite: true


### PR DESCRIPTION
In the `publish_gh` job the `svenstaro/upload-release-action@v2` action does not require a `repo_token` and will default to `github.token` (see the action [README](https://github.com/svenstaro/upload-release-action/blob/v2/README.md)). The `github.token` is autogenerated during workflow runs (see the [documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication)) and will work just fine for publishing to releases.

I have updated this in the [AWX Runner](https://github.com/networktocode-llc/nautobot-plugin-awx-runner/blob/2d8f143693e68863c6b2eac760d09007ada84b4b/.github/workflows/ci.yml#L224) repo and it [worked fine](https://github.com/networktocode-llc/nautobot-plugin-awx-runner/actions/runs/10719631200/job/29724671931).