### PR TITLE
Drift Manager Improvements

### DIFF
--- a/.github/workflows/tag-nautobot-app-v2.yml
+++ b/.github/workflows/tag-nautobot-app-v2.yml
@@ -38,5 +38,9 @@ jobs:
           python -m ntc_cookie_drift_manager \
             rebake \
             --push \
+            --post-action=ruff \
+            --post-action=poetry \
+            --disable-post-actions=black \
+            --no-draft \
             --template-ref="${{ github.ref }}" \
             https://github.com/nautobot/nautobot-app-${{ matrix.name }}.git

--- a/nautobot-app/{{ cookiecutter.project_slug }}/development/towncrier_template.j2
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/development/towncrier_template.j2
@@ -12,7 +12,11 @@
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
 {% for item in text.split('\n') %}
+{% if values %}
 - {{ values|join(', ') }} - {{ item.strip() }}
+{% else %}
+- {{ item.strip() }}
+{% endif %}
 {% endfor %}
 {% endfor %}
 


### PR DESCRIPTION
This PR removes black as a post-action, then adds Ruff and Poetry lock. 

The template change allows the new change fragment format to render properly when using generate-release-notes. That is, when adding a change that is not linked to a PR/Issue it removes the leading hyphen.

I also changed the PR status to Ready instead of Draft when it opens.  I can remove this, but with these changes and the change fragment from the Drift Manager PR, there will hopefully be little we need to do.