### PR TITLE
Disable-post-actions is a boolean

### DIFF
--- a/.github/workflows/tag-nautobot-app-v2.yml
+++ b/.github/workflows/tag-nautobot-app-v2.yml
@@ -40,7 +40,7 @@ jobs:
             --push \
             --post-action=ruff \
             --post-action=poetry \
-            --disable-post-actions=black \
+            --disable-post-actions \
             --no-draft \
             --template-ref="${{ github.ref }}" \
             https://github.com/nautobot/nautobot-app-${{ matrix.name }}.git


### PR DESCRIPTION
Jan caught that `disable-post-actions` is a boolean instead of accepting an argument. With the latest release of drift manager, this will now disable all existing post-actions from the .cookiecutter.json and replace them with the `post-action` args that are passed into the rebake command.