### PR TITLE
release v2.4.0

### DIFF
--- a/changes/109.fixed
+++ b/changes/109.fixed
@@ -1,1 +1,0 @@
-Fixed links to templates in docs index.

--- a/changes/118.fixed
+++ b/changes/118.fixed
@@ -1,1 +1,0 @@
-Updated docs build to activate the link on the Installed Apps page.

--- a/changes/183.added
+++ b/changes/183.added
@@ -1,1 +1,0 @@
-Added pylint django migrations checker to the `invoke pylint` command.

--- a/development/towncrier_template.j2
+++ b/development/towncrier_template.j2
@@ -1,0 +1,41 @@
+# v{{ versiondata.version.split(".")[:2] | join(".") }} Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Major features or milestones
+- Changes to compatibility with Nautobot and/or other apps, libraries etc.
+
+{% if render_title %}
+## [v{{ versiondata.version }} ({{ versiondata.date }})](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/v{{ versiondata.version}})
+
+{% endif %}
+{% for section, _ in sections.items() %}
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section] %}
+{% if sections[section][category]|length != 0 %}
+### {{ definitions[category]['name'] }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+{% for item in text.split('\n') %}
+{% if values %}
+- {{ values|join(', ') }} - {{ item.strip() }}
+{% else %}
+- {{ item.strip() }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+
+{% else %}
+- {{ sections[section][category]['']|join(', ') }}
+
+{% endif %}
+{% endif %}
+{% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}
+{% endfor %}

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -1,0 +1,35 @@
+# v2.4 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Various CI fixes for pull requests and upstream testing.
+- Various documentation updates and fixes.
+
+## [v2.4.0 (2024-10-10)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/v2.4.0)
+
+### Added
+
+- [#117](https://github.com/nautobot/cookiecutter-nautobot-app/issues/117) - Added environment variable `NAUTOBOT_LOG_DEPRECATION_WARNINGS=True` to development environment to enable deprecation warnings.
+- [#180](https://github.com/nautobot/cookiecutter-nautobot-app/issues/180) - Added "backporting" section to contributing docs.
+- [#183](https://github.com/nautobot/cookiecutter-nautobot-app/issues/183) - Added pylint django migrations checker to the `invoke pylint` command.
+
+### Changed
+
+- [#115](https://github.com/nautobot/cookiecutter-nautobot-app/issues/115) - Changed `invoke generate-release-notes` to always run locally.
+- [#144](https://github.com/nautobot/cookiecutter-nautobot-app/issues/144) - Updated release checklist documentation.
+- [#144](https://github.com/nautobot/cookiecutter-nautobot-app/issues/144) - Updated ci workflow to skip `changelog` step on release branches.
+- [#157](https://github.com/nautobot/cookiecutter-nautobot-app/issues/157) - Further cleanup of bandit remnants.
+- [#157](https://github.com/nautobot/cookiecutter-nautobot-app/issues/157) - Disabled pylint ruff rules as pylint is still being used.
+- [#165](https://github.com/nautobot/cookiecutter-nautobot-app/issues/165) - Updated drift manager post actions to remove `black` and add `ruff`, `poetry lock` and add a changelog fragment to the drift manager pull request.
+
+### Fixed
+
+- [#109](https://github.com/nautobot/cookiecutter-nautobot-app/issues/109) - Fixed links to templates in docs index.
+- [#118](https://github.com/nautobot/cookiecutter-nautobot-app/issues/118) - Updated docs build to activate the link on the Installed Apps page.
+- [#128](https://github.com/nautobot/cookiecutter-nautobot-app/issues/128) - Fixed urls in readmes and docs.
+- [#134](https://github.com/nautobot/cookiecutter-nautobot-app/issues/134) - Fixed typo in upstream testing workflow.
+- [#166](https://github.com/nautobot/cookiecutter-nautobot-app/issues/166) - Fixed `invoke ruff` not properly exiting with non-zero status when a ruff check fails.
+- [#167](https://github.com/nautobot/cookiecutter-nautobot-app/issues/167) - Fixed missing variable in upstream testing workflow.
+- [#170](https://github.com/nautobot/cookiecutter-nautobot-app/issues/170) - Fixed Dockerfile to allow installing Nautobot from a branch as well as a tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,55 @@ testpaths = [
     "nautobot-app-ssot/tests",
 ]
 addopts = "--color=yes"
+
+[tool.towncrier]
+directory = "changes"
+filename = "docs/admin/release_notes/version_X.Y.md"
+template = "development/towncrier_template.j2"
+start_string = "<!-- towncrier release notes start -->"
+issue_format = "[#{issue}](https://github.com/nautobot/cookiecutter-nautobot-app/issues/{issue})"
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "dependencies"
+name = "Dependencies"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "documentation"
+name = "Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "housekeeping"
+name = "Housekeeping"
+showcontent = true


### PR DESCRIPTION
## [v2.4.0 (2024-10-10)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/v2.4.0)

### Added

- [#117](https://github.com/nautobot/cookiecutter-nautobot-app/issues/117) - Added environment variable `NAUTOBOT_LOG_DEPRECATION_WARNINGS=True` to development environment to enable deprecation warnings.
- [#180](https://github.com/nautobot/cookiecutter-nautobot-app/issues/180) - Added "backporting" section to contributing docs.
- [#183](https://github.com/nautobot/cookiecutter-nautobot-app/issues/183) - Added pylint django migrations checker to the `invoke pylint` command.

### Changed

- [#115](https://github.com/nautobot/cookiecutter-nautobot-app/issues/115) - Changed `invoke generate-release-notes` to always run locally.
- [#144](https://github.com/nautobot/cookiecutter-nautobot-app/issues/144) - Updated release checklist documentation.
- [#144](https://github.com/nautobot/cookiecutter-nautobot-app/issues/144) - Updated ci workflow to skip `changelog` step on release branches.
- [#157](https://github.com/nautobot/cookiecutter-nautobot-app/issues/157) - Further cleanup of bandit remnants.
- [#157](https://github.com/nautobot/cookiecutter-nautobot-app/issues/157) - Disabled pylint ruff rules as pylint is still being used.
- [#165](https://github.com/nautobot/cookiecutter-nautobot-app/issues/165) - Updated drift manager post actions to remove `black` and add `ruff`, `poetry lock` and add a changelog fragment to the drift manager pull request.

### Fixed

- [#109](https://github.com/nautobot/cookiecutter-nautobot-app/issues/109) - Fixed links to templates in docs index.
- [#118](https://github.com/nautobot/cookiecutter-nautobot-app/issues/118) - Updated docs build to activate the link on the Installed Apps page.
- [#128](https://github.com/nautobot/cookiecutter-nautobot-app/issues/128) - Fixed urls in readmes and docs.
- [#134](https://github.com/nautobot/cookiecutter-nautobot-app/issues/134) - Fixed typo in upstream testing workflow.
- [#166](https://github.com/nautobot/cookiecutter-nautobot-app/issues/166) - Fixed `invoke ruff` not properly exiting with non-zero status when a ruff check fails.
- [#167](https://github.com/nautobot/cookiecutter-nautobot-app/issues/167) - Fixed missing variable in upstream testing workflow.
- [#170](https://github.com/nautobot/cookiecutter-nautobot-app/issues/170) - Fixed Dockerfile to allow installing Nautobot from a branch as well as a tag.
