### PR TITLE
Make urls.py a file that is always baked

### DIFF
--- a/nautobot-app/hooks/post_gen_project.py
+++ b/nautobot-app/hooks/post_gen_project.py
@@ -43,7 +43,6 @@ if __name__ == "__main__":
             "tests/test_form_{{ cookiecutter.model_class_name.lower() }}.py",
             "tests/test_model_{{ cookiecutter.model_class_name.lower() }}.py",
             "tests/test_views.py",
-            "urls.py",
             "views.py",
         ]
         for file in files_to_remove:

--- a/nautobot-app/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/urls.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/urls.py
@@ -5,10 +5,20 @@ from django.urls import path
 from django.views.generic import RedirectView
 from nautobot.apps.urls import NautobotUIViewSetRouter
 
+{% if cookiecutter.model_class_name != "None" %}
 from {{ cookiecutter.app_name }} import views
+{% else %}
+# Uncomment the following line if you have views to import
+# from {{ cookiecutter.app_name }} import views
+{% endif %}
 
 router = NautobotUIViewSetRouter()
+{% if cookiecutter.model_class_name != "None" %}
 router.register("{{ cookiecutter.model_class_name | lower }}", views.{{ cookiecutter.model_class_name }}UIViewSet)
+{% else %}
+# Here is an example of how to register a viewset, you will want to replace views.{{ cookiecutter.camel_name }}UIViewSet with your viewset
+# router.register("{{ cookiecutter.app_name }}", views.{{ cookiecutter.camel_name }}UIViewSet)
+{% endif %}
 
 urlpatterns = [
     path("docs/", RedirectView.as_view(url=static("{{ cookiecutter.app_name }}/docs/index.html")), name="docs"),


### PR DESCRIPTION
Closes #196 

Post Bake of urls.py with model_class_name==None:
```
"""Django urlpatterns declaration for test_app app."""

from django.templatetags.static import static
from django.urls import path
from django.views.generic import RedirectView
from nautobot.apps.urls import NautobotUIViewSetRouter


# Uncomment the following line if you have views to import
# from test_app import views


router = NautobotUIViewSetRouter()

# Here is an example of how to register a viewset, you will want to replace views.TestAppUIViewSet with your viewset
# router.register("test_app", views.TestAppUIViewSet)


urlpatterns = [
    path("docs/", RedirectView.as_view(url=static("test_app/docs/index.html")), name="docs"),
]

urlpatterns += router.urls
```

DRF does not complain when providing a router with no viewsets.

<img width="1315" alt="image" src="https://github.com/user-attachments/assets/1bb0cb62-aab1-4dda-85d1-3bc16d2c0cbf">
