### PR TITLE
Adds unit-test xml report generation task

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -853,6 +853,13 @@ def unittest_coverage(context):
     run_command(context, command)
 
 
+@task(pre=[unittest])
+def unittest_xml_coverage(context):
+    """Produce an XML coverage report that can be ingested into other tools."""
+    produce_xml_cmd = "coverage xml"
+    run_command(context, produce_xml_cmd)
+
+
 @task(
     help={
         "failfast": "fail as soon as a single test fails don't run the entire test suite. (default: False)",


### PR DESCRIPTION
## What's Changed

- Adds a invoke helper task to generate an xml report file (`coverage.xml`). This can be used by tooling (such as VSCode code coverage extensions) for ingestion.

~Of note that the XML has to be modified to work correctly with tooling outside the container. I first tried to use the std-lib xml to do this but received a `ruff` CVE warning. I didn't want to pull in a new dependency here, so I did the hacky thing to just manipulate the file with string replacement. Open to feedback whether that was the right call or not.~

Earlier commit i worked around a CVE in XML but after feedback decided it was acceptable for dev environments and went back to using the stdlib xml helpers.

## Testing

Tested this logic in the floor-plan app while I was reviewing a PR and it worked fine.