### PR TITLE
Adds automatic creds.env copy

### DIFF
--- a/docs/user/quick-start.md
+++ b/docs/user/quick-start.md
@@ -49,7 +49,6 @@ Congratulations! Your cookie has now been baked. It is located at /tmp/nautobot-
 ⚠️⚠️ Before you start using your cookie you must run the following commands inside your cookie:
 
 * poetry lock
-* cp development/creds.example.env development/creds.env
 * poetry install
 * poetry shell
 * invoke makemigrations
@@ -166,13 +165,12 @@ Congratulations! Your cookie has now been baked. It is located at /tmp/nautobot-
 ⚠️⚠️ Before you start using your cookie you must run the following commands inside your cookie:
 
 * poetry lock
-* cp development/creds.example.env development/creds.env
 * poetry install
 * poetry shell
 * invoke makemigrations
 * ruff . # this will ensure all python files are formatted correctly, may require `sudo chown -R <my local username> ./` as migrations may be owned by root
 
-The file `creds.env` will be ignored by git and can be used to override default environment variables.
+Note: The file `development/creds.env` may be automatically created and ignored by git. It can be used to override default environment variables within the docker containers.
 ```
 
 The cookiecutter CLI tool uses the default branch when using the above example command, to use a different branch, commit, or tag the `--checkout` command line argument can be used.

--- a/nautobot-app-chatops/hooks/post_gen_project.py
+++ b/nautobot-app-chatops/hooks/post_gen_project.py
@@ -11,13 +11,12 @@ Congratulations! Your cookie has now been baked. It is located at {_PROJECT_PATH
 ⚠️⚠️ Before you start using your cookie you must run the following commands inside your cookie:
 
 * poetry lock
-* cp development/creds.example.env development/creds.env
 * poetry install
 * poetry shell
 * invoke makemigrations
 * inv ruff --fix # this will ensure all python files are formatted correctly, may require `sudo chown -R $USER ./` as migrations may be owned by root
 
-The file `creds.env` will be ignored by git and can be used to override default environment variables.
+Note: The file `development/creds.env` may be automatically created and ignored by git. It can be used to override default environment variables within the docker containers.
 """
 
 if __name__ == "__main__":

--- a/nautobot-app/hooks/post_gen_project.py
+++ b/nautobot-app/hooks/post_gen_project.py
@@ -11,13 +11,12 @@ Congratulations! Your cookie has now been baked. It is located at {_PROJECT_PATH
 ⚠️⚠️ Before you start using your cookie you must run the following commands inside your cookie:
 
 * poetry lock
-* cp development/creds.example.env development/creds.env
 * poetry install
 * poetry shell
 * invoke makemigrations
 * invoke ruff --fix # this will ensure all python files are formatted correctly, may require `sudo chown -R $USER ./` as migrations may be owned by root
 
-The file `creds.env` will be ignored by git and can be used to override default environment variables.
+Note: The file `development/creds.env` may be automatically created and ignored by git. It can be used to override default environment variables within the docker containers.
 """
 
 if __name__ == "__main__":

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -125,8 +125,6 @@ jobs:
             NAUTOBOT_VER={% raw %}${{ matrix.nautobot-version }}{% endraw %}
             PYTHON_VER={% raw %}${{ matrix.python-version }}{% endraw %}
             CI=true
-      - name: "Copy credentials"
-        run: "cp development/creds.example.env development/creds.env"
       - name: "Linting: pylint"
         run: "poetry run invoke pylint"
       - name: "Checking: App Config"
@@ -182,8 +180,6 @@ jobs:
             NAUTOBOT_VER={% raw %}${{ matrix.nautobot-version }}{% endraw %}
             PYTHON_VER={% raw %}${{ matrix.python-version }}{% endraw %}
             CI=true
-      - name: "Copy credentials"
-        run: "cp development/creds.example.env development/creds.env"
       - name: "Use Mysql invoke settings when needed"
         run: "cp invoke.mysql.yml invoke.yml"
         if: "matrix.db-backend == 'mysql'"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/dev_environment.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/dev_environment.md
@@ -38,7 +38,6 @@ Once you have Poetry and Docker installed you can run the following commands (in
 ```shell
 poetry shell
 poetry install
-cp development/creds.example.env development/creds.env
 invoke build
 invoke start
 ```
@@ -159,7 +158,7 @@ This project is set up with a number of **Invoke** tasks consumed as simple CLI 
 
 ### Copy the credentials file for Nautobot
 
-First, you need to create the `development/creds.env` file - it stores a bunch of private information such as passwords and tokens for your local Nautobot install. You can make a copy of the `development/creds.example.env` and modify it to suit you.
+First, you may create/overwrite the `development/creds.env` file - it stores a bunch of private information such as passwords and tokens for your local Nautobot install. You can make a copy of the `development/creds.example.env` and modify it to suit you.
 
 ```shell
 cp development/creds.example.env development/creds.env

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -14,8 +14,8 @@ limitations under the License.
 
 import os
 import re
-import sys
 import shutil
+import sys
 from pathlib import Path
 from time import sleep
 

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -15,6 +15,7 @@ limitations under the License.
 import os
 import re
 import sys
+import shutil
 from pathlib import Path
 from time import sleep
 
@@ -118,6 +119,7 @@ def docker_compose(context, command, **kwargs):
         command (str): Command string to append to the "docker compose ..." command, such as "build", "up", etc.
         **kwargs: Passed through to the context.run() call.
     """
+    _ensure_creds_env_file(context)
     build_env = {
         # Note: 'docker compose logs' will stop following after 60 seconds by default,
         # so we are overriding that by setting this environment variable.
@@ -200,6 +202,23 @@ def build(context, force_rm=False, cache=True):
     print(f"Building Nautobot with Python {context.{{ cookiecutter.app_name }}.python_ver}...")
     docker_compose(context, command)
 
+
+def _ensure_creds_env_file(context):
+    """Ensure that the development/creds.env file exists."""
+    if not os.path.exists(
+        os.path.join(context.{{ cookiecutter.app_name }}.compose_dir, "creds.env")
+    ):
+        # Warn the user that the creds.env file does not exist and that we are copying the example file to it
+        print(
+            "⚠️⚠️ The creds.env file does not exist, using the example file to create it. ⚠️⚠️"
+        )
+        # Copy the creds.example.env file to creds.env
+        shutil.copy(
+            os.path.join(
+                context.{{ cookiecutter.app_name }}.compose_dir, "creds.example.env"
+            ),
+            os.path.join(context.{{ cookiecutter.app_name }}.compose_dir, "creds.env"),
+        )
 
 @task
 def generate_packages(context):


### PR DESCRIPTION
# Closes #216

## What's Changed
This PR adds a simple function to `tasks.py` that looks for the absence of the `development/creds.env` file and copies the example file if it's missing.

## To Do

- [x] Update the documentation.
- [ ] Add changelog.
