### PR TITLE
Add Design Builder to Drift Manager

### DIFF
--- a/.github/workflows/tag-nautobot-app-v2.yml
+++ b/.github/workflows/tag-nautobot-app-v2.yml
@@ -20,6 +20,7 @@ jobs:
           - "chatops"
           - "circuit-maintenance"
           - "data-validation-engine"
+          - "design-builder"
           - "dev-example"
           - "device-lifecycle-mgmt"
           - "device-onboarding"


### PR DESCRIPTION
## What's Changed

Add Design Builder to Drift Manager.

Design Builder's `drift-manager/baked` has been reset with Cookiecutter-nautobot-app 2.4.2.
