### PR TITLE
Remove jquery loading for RTD

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
@@ -46,12 +46,6 @@ theme:
 extra_css:
   - "assets/extra.css"
 
-# needed for RTD version flyout menu
-# jquery is not (yet) injected by RTD automatically and it might be dropped
-# as a dependency in the future
-extra_javascript:
-  - "https://code.jquery.com/jquery-3.6.0.min.js"
-
 extra:
   generator: false
   ntc_sponsor: true


### PR DESCRIPTION
# Closes N/A

## What's Changed

JQuery is not needed anymore with their new plugin system. Live tested in https://docs.nautobot.com/projects/dns-models/en/latest/ - this was originally added for the version selection flyout menu that RTD injects into their hosted docs.