### PR TITLE
Enforce mkdocs docs are actually referenced.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,11 +95,12 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
-          - v1.0: "admin/release_notes/version_1.0.md"
-          - v2.0: "admin/release_notes/version_2.0.md"
-          - v2.1: "admin/release_notes/version_2.1.md"
-          - v2.2: "admin/release_notes/version_2.2.md"
+          - v2.4: "admin/release_notes/version_2.4.md"
           - v2.3: "admin/release_notes/version_2.3.md"
+          - v2.2: "admin/release_notes/version_2.2.md"
+          - v2.1: "admin/release_notes/version_2.1.md"
+          - v2.0: "admin/release_notes/version_2.0.md"
+          - v1.0: "admin/release_notes/version_1.0.md"
       - Drift Management: "admin/drift_management.md"
   - Developer Guide:
       - Contributing: "dev/contributing.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,10 @@ plugins:
 watch:
   - "README.md"
 
+validation:
+  nav:
+    omitted_files: "warn"
+
 nav:
   - Overview: "index.md"
   - User Guide:

--- a/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
@@ -101,6 +101,10 @@ plugins:
 watch:
   - "README.md"
 
+validation:
+  nav:
+    omitted_files: "warn"
+
 nav:
   - Overview: "index.md"
   - User Guide:

--- a/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
@@ -102,8 +102,10 @@ watch:
   - "README.md"
 
 validation:
-  nav:
-    omitted_files: "warn"
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
 
 nav:
   - Overview: "index.md"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/mkdocs.yml
@@ -102,10 +102,10 @@ watch:
   - "README.md"
 
 validation:
-  omitted_files: warn
-  absolute_links: warn
-  unrecognized_links: warn
-  anchors: warn
+  omitted_files: "warn"
+  absolute_links: "warn"
+  unrecognized_links: "warn"
+  anchors: "warn"
 
 nav:
   - Overview: "index.md"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -672,6 +672,17 @@ def build_and_check_docs(context):
     command = "mkdocs build --no-directory-urls --strict"
     run_command(context, command)
 
+    # Check for the existence of a release notes file for the current version if it's not a prerelease.
+    version = context.run("poetry version --short", hide=True)
+    match = re.match(r"^(\d+)\.(\d+)\.\d+$", version.stdout.strip())
+    if match:
+        major = match.group(1)
+        minor = match.group(2)
+        release_notes_file = Path(__file__).parent / "docs" / "admin" / "release_notes" / f"version_{major}.{minor}.md"
+        if not release_notes_file.exists():
+            print(f"Release notes file `version_{major}.{minor}.md` does not exist.")
+            raise Exit(code=1)
+
 
 @task(name="help")
 def help_task(context):

--- a/nautobot-app/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/tests/test_basic.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/tests/test_basic.py
@@ -1,6 +1,7 @@
 """Basic tests that do not require Django."""
 
 import os
+import re
 import unittest
 
 import toml
@@ -23,3 +24,25 @@ class TestDocsPackaging(unittest.TestCase):
             else:
                 version = "*"
             self.assertEqual(poetry_details[package_name], version)
+
+
+class TestDocsReleaseNotes(unittest.TestCase):
+    """Test that mkdocs has the release notes for the current version."""
+
+    def test_version_file_found(self):
+        """Verify that if the current version has no letters, which would see in alpha or beta has an associated release note file."""
+        parent_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+        poetry_path = os.path.join(parent_path, "pyproject.toml")
+        project_version = toml.load(poetry_path)["tool"]["poetry"]["version"]
+
+        docs_path = os.path.join(parent_path, "docs")
+        release_notes_files = [file for file in os.listdir(f"{docs_path}/admin/release_notes/") if file.endswith(".md")]
+        version_pattern = re.compile(r"^(\d+)\.(\d+)\.\d+$")
+
+        match = version_pattern.match(project_version)
+        # If there is no match, then it is likely an alpha or beta version and we can skip this test.
+        if match:
+            major, minor = match.groups()
+            version_str = f"version_{major}.{minor}.md"
+            if version_str not in release_notes_files:
+                self.fail(f"Release note file for version {version_str} not found in release notes folder.")

--- a/nautobot-app/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/tests/test_basic.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/tests/test_basic.py
@@ -1,7 +1,6 @@
 """Basic tests that do not require Django."""
 
 import os
-import re
 import unittest
 
 import toml
@@ -24,25 +23,3 @@ class TestDocsPackaging(unittest.TestCase):
             else:
                 version = "*"
             self.assertEqual(poetry_details[package_name], version)
-
-
-class TestDocsReleaseNotes(unittest.TestCase):
-    """Test that mkdocs has the release notes for the current version."""
-
-    def test_version_file_found(self):
-        """Verify that if the current version has no letters, which would see in alpha or beta has an associated release note file."""
-        parent_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
-        poetry_path = os.path.join(parent_path, "pyproject.toml")
-        project_version = toml.load(poetry_path)["tool"]["poetry"]["version"]
-
-        docs_path = os.path.join(parent_path, "docs")
-        release_notes_files = [file for file in os.listdir(f"{docs_path}/admin/release_notes/") if file.endswith(".md")]
-        version_pattern = re.compile(r"^(\d+)\.(\d+)\.\d+$")
-
-        match = version_pattern.match(project_version)
-        # If there is no match, then it is likely an alpha or beta version and we can skip this test.
-        if match:
-            major, minor = match.groups()
-            version_str = f"version_{major}.{minor}.md"
-            if version_str not in release_notes_files:
-                self.fail(f"Release note file for version {version_str} not found in release notes folder.")


### PR DESCRIPTION
# Closes N/A

## What's Changed

- Turned on enforcement to ensure all docs that are created are referenced in the navigation. 
- Added check for current version has a release note, taken into consideration alpha / beta versions. 



## To Do

