### PR TITLE
Fixes terminology for Slack channel

### DIFF
--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -33,4 +33,3 @@ This document describes all new features and changes in the release. The format 
 - [#166](https://github.com/nautobot/cookiecutter-nautobot-app/issues/166) - Fixed `invoke ruff` not properly exiting with non-zero status when a ruff check fails.
 - [#167](https://github.com/nautobot/cookiecutter-nautobot-app/issues/167) - Fixed missing variable in upstream testing workflow.
 - [#170](https://github.com/nautobot/cookiecutter-nautobot-app/issues/170) - Fixed Dockerfile to allow installing Nautobot from a branch as well as a tag.
-- [#237](https://github.com/nautobot/cookiecutter-nautobot-app/issues/237) - Fixed terminology in the footer of docs.

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -33,3 +33,4 @@ This document describes all new features and changes in the release. The format 
 - [#166](https://github.com/nautobot/cookiecutter-nautobot-app/issues/166) - Fixed `invoke ruff` not properly exiting with non-zero status when a ruff check fails.
 - [#167](https://github.com/nautobot/cookiecutter-nautobot-app/issues/167) - Fixed missing variable in upstream testing workflow.
 - [#170](https://github.com/nautobot/cookiecutter-nautobot-app/issues/170) - Fixed Dockerfile to allow installing Nautobot from a branch as well as a tag.
+- [#237](https://github.com/nautobot/cookiecutter-nautobot-app/issues/237) - Fixed terminology in the footer of docs.

--- a/docs/assets/overrides/partials/copyright.html
+++ b/docs/assets/overrides/partials/copyright.html
@@ -10,7 +10,7 @@
 <div class="md-copyright">
     <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">Made with Material for
         MkDocs</a>
-    | <a href="https://www.networktocode.com/community/" target="_blank" rel="noopener">Join Nautobot Slack</a>
+    | <a href="https://www.networktocode.com/community/open-source/" target="_blank" rel="noopener">Join #Nautobot on the Network to Code Slack</a>
     {% if config.extra.ntc_sponsor == true %}
     | <a href="https://networktocode.com" target="_blank" rel="noopener">Sponsored by <img
             src={{ "assets/networktocode_bw.png" | url }} class="copyright-logo"></a>

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/assets/overrides/partials/copyright.html
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/assets/overrides/partials/copyright.html
@@ -10,7 +10,7 @@
 
 <div class="md-copyright">
     <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">Made with Material for MkDocs</a>
-    | <a href="https://www.networktocode.com/community/" target="_blank" rel="noopener">Join Nautobot Slack</a>
+    | <a href="https://www.networktocode.com/community/open-source/" target="_blank" rel="noopener">Join #Nautobot on the Network to Code Slack</a>
     {% if config.extra.ntc_sponsor == true %}
     | <a href="https://networktocode.com" target="_blank" rel="noopener">Sponsored by <img
             src={{ "assets/networktocode_bw.png" | url }} class="copyright-logo"></a>


### PR DESCRIPTION
# Closes #237 

## What's Changed

- Changed the slack to include the #nautobot channel on NTC Slack
- Changed the link to the page that has the sign up for Slack link

## To Do

- [x] Update the documentation.
- [x] Add changelog.
