### PR TITLE
Pin github actions to their commit refs instead of tags/branches.

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
       - name: "Run Poetry Build"
         run: "poetry build"
       - name: "Upload binaries to release"
-        run: "gh release upload {% raw %}${{ github.ref }} dist/*.{tar.gz,whl}{% endraw %}"
+        run: "gh release upload {% raw %}${{ github.ref_name }} dist/*.{tar.gz,whl}{% endraw %}"
         env:
           GH_TOKEN: "{% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}"
   publish_pypi:

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -109,9 +109,9 @@ jobs:
         run: "poetry run invoke lock --constrain-nautobot-ver --constrain-python-ver"
       - name: "Set up Docker Buildx"
         id: "buildx"
-        uses: "docker/setup-buildx-action@v3"
+        uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0
       - name: "Build"
-        uses: "docker/build-push-action@v5"
+        uses: "docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25"  # v5.4.0
         with:
           builder: "{% raw %}${{ steps.buildx.outputs.name }}{% endraw %}"
           context: "./"
@@ -166,9 +166,9 @@ jobs:
         run: "poetry run invoke lock --constrain-nautobot-ver --constrain-python-ver"
       - name: "Set up Docker Buildx"
         id: "buildx"
-        uses: "docker/setup-buildx-action@v3"
+        uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0
       - name: "Build"
-        uses: "docker/build-push-action@v5"
+        uses: "docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25"  # v5.4.0
         with:
           builder: "{% raw %}${{ steps.buildx.outputs.name }}{% endraw %}"
           context: "./"
@@ -216,6 +216,8 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/v')"
     env:
       INVOKE_{{ cookiecutter.app_name.upper() }}_LOCAL: "True"
+    permissions:
+      contents: "write"
     steps:
       - name: "Check out repository code"
         uses: "actions/checkout@v4"
@@ -236,13 +238,9 @@ jobs:
       - name: "Run Poetry Build"
         run: "poetry build"
       - name: "Upload binaries to release"
-        uses: "svenstaro/upload-release-action@v2"
-        with:
-          repo_token: "{% raw %}${{ secrets.NTC_GITHUB_TOKEN }}{% endraw %}"  # use GH_NAUTOBOT_BOT_TOKEN for Nautobot Org repos.
-          file: "dist/*"
-          tag: "{% raw %}${{ github.ref }}{% endraw %}"
-          overwrite: true
-          file_glob: true
+        run: "gh release upload {% raw %}${{ github.ref }} dist/*.{tar.gz,whl}{% endraw %}"
+        env:
+          GH_TOKEN: "{% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}"
   publish_pypi:
     needs:
       - "unittest"
@@ -271,7 +269,7 @@ jobs:
       - name: "Run Poetry Build"
         run: "poetry build"
       - name: "Push to PyPI"
-        uses: "pypa/gh-action-pypi-publish@release/v1"
+        uses: "pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc"  # v1.12.4
         with:
           user: "__token__"
           password: "{% raw %}${{ secrets.PYPI_API_TOKEN }}{% endraw %}"
@@ -292,7 +290,7 @@ jobs:
         # ENVs cannot be used directly in job.if. This is a workaround to check
         # if SLACK_WEBHOOK_URL is present.
         if: "env.SLACK_WEBHOOK_URL != ''"
-        uses: "slackapi/slack-github-action@v1"
+        uses: "slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3"  # v1.27.1
         with:
           payload: |
             {

--- a/nautobot-app/{{ cookiecutter.project_slug }}/development/towncrier_template.j2
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/development/towncrier_template.j2
@@ -1,9 +1,7 @@
 {% raw %}
 # v{{ versiondata.version.split(".")[:2] | join(".") }} Release Notes
 
-This document describes all new features and changes in the release. The format is based on [Keep a
-Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic
-Versioning](https://semver.org/spec/v2.0.0.html).
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Release Overview
 

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -251,7 +251,6 @@ def lock(context, check=False, constrain_nautobot_ver=False, constrain_python_ve
         if constrain_python_ver:
             command += f" --python {context.{{ cookiecutter.app_name }}.python_ver}"
         try:
-            run_command(context, command, hide=True)
             output = run_command(context, command, hide=True)
             print(output.stdout, end="")
             print(output.stderr, file=sys.stderr, end="")


### PR DESCRIPTION
# Closes #DNE

## What's Changed

- Pin github actions to their commit refs instead of tags/branches
- Remove third party "github release" action in release workflow 
- Fixed small bugs.