### PR TITLE
fix pymarkdownlnt to work with python 3.8

### DIFF
--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -49,7 +49,10 @@ ruff = "0.5.5"
 yamllint = "*"
 toml = "*"
 # Python implementation of markdownlint
-pymarkdownlnt = "~0.9.29"
+pymarkdownlnt = [
+    {version = "0.9.26", python = "~3.8.0"},
+    {version = "~0.9.29", python = ">=3.9,<3.13"},
+]
 Markdown = "*"
 # Render custom markdown for version added/changed/remove notes
 markdown-version-annotations = "1.0.1"
@@ -193,7 +196,7 @@ plugins.md049.enabled = false
 plugins.md050.enabled = false
 plugins.pml100.enabled = false
 plugins.pml101.enabled = true # list-anchored-indent
-plugins.pml102.enabled = false 
+plugins.pml102.enabled = false
 plugins.pml103.enabled = false
 
 [build-system]

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -47,7 +47,10 @@ ruff = "0.5.5"
 yamllint = "*"
 toml = "*"
 # Python implementation of markdownlint
-pymarkdownlnt = "~0.9.29"
+pymarkdownlnt = [
+    {version = "0.9.26", python = "~3.8.0"},
+    {version = "~0.9.29", python = ">=3.9,<3.13"},
+]
 Markdown = "*"
 # Render custom markdown for version added/changed/remove notes
 markdown-version-annotations = "1.0.1"
@@ -190,7 +193,7 @@ plugins.md049.enabled = false
 plugins.md050.enabled = false
 plugins.pml100.enabled = false
 plugins.pml101.enabled = true # list-anchored-indent
-plugins.pml102.enabled = false 
+plugins.pml102.enabled = false
 plugins.pml103.enabled = false
 
 [build-system]

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -46,7 +46,10 @@ ruff = "0.5.5"
 yamllint = "*"
 toml = "*"
 # Python implementation of markdownlint
-pymarkdownlnt = "~0.9.29"
+pymarkdownlnt = [
+    {version = "0.9.26", python = "~3.8.0"},
+    {version = "~0.9.29", python = ">=3.9,<3.13"},
+]
 Markdown = "*"
 # Render custom markdown for version added/changed/remove notes
 markdown-version-annotations = "1.0.1"
@@ -189,7 +192,7 @@ plugins.md049.enabled = false
 plugins.md050.enabled = false
 plugins.pml100.enabled = false
 plugins.pml101.enabled = true # list-anchored-indent
-plugins.pml102.enabled = false 
+plugins.pml102.enabled = false
 plugins.pml103.enabled = false
 
 [build-system]


### PR DESCRIPTION
# Closes #DNE

## What's Changed


## To Do

- [ ] Update the documentation.
- [ ] Add changelog.
