### PR TITLE
Add DNS Models to drift-manager

### DIFF
--- a/.github/workflows/tag-nautobot-app-v2.yml
+++ b/.github/workflows/tag-nautobot-app-v2.yml
@@ -24,6 +24,7 @@ jobs:
           - "dev-example"
           - "device-lifecycle-mgmt"
           - "device-onboarding"
+          - "dns-models"
           - "firewall-models"
           - "floor-plan"
           - "golden-config"


### PR DESCRIPTION
## What's Changed

Adds dns-models to the list of apps to drift-manage.

## To Do

- [ ] Update the documentation.
- [ ] Add changelog.
