### PR TITLE
Require the unittest_report for publish jobs.

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -295,6 +295,7 @@ jobs:
   publish_gh:
     needs:
       - "unittest"
+      - "unittest_report"
     name: "Publish to GitHub"
     runs-on: "ubuntu-22.04"
     if: "startsWith(github.ref, 'refs/tags/v')"
@@ -330,6 +331,7 @@ jobs:
   publish_pypi:
     needs:
       - "unittest"
+      - "unittest_report"
     name: "Push Package to PyPI"
     runs-on: "ubuntu-22.04"
     if: "startsWith(github.ref, 'refs/tags/v')"


### PR DESCRIPTION
Since we removed the 3.12-STABLE test from unittest, we should require the unittest_report to complete since it will still fail if unittest_report fails.