### PR TITLE
Fix front-matter YAML and enable mdlint extension

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/index.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/index.md
@@ -1,8 +1,6 @@
 ---
 hide:
-
-    - navigation
-
+  - navigation
 ---
 
 --8<-- "README.md"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -205,6 +205,7 @@ plugins.pml100.enabled = false
 plugins.pml101.enabled = true # list-anchored-indent
 plugins.pml102.enabled = false
 plugins.pml103.enabled = false
+extensions.front-matter.enabled = true
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]


### PR DESCRIPTION
# Closes #DNE

## What's Changed

- Reverts markdown formatting of YAML front-matter and makes markdownlint aware of such sections.
