### PR TITLE
fix: :bug: Fix NautobotAdapter not defined NameError on makemigrations

### DIFF
--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/diffsync/adapters.py
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/{{ cookiecutter.app_name }}/diffsync/adapters.py
@@ -1,6 +1,7 @@
 """Diffsync adapters for {{ cookiecutter.app_name }}."""
 
 from diffsync import Adapter
+from nautobot_ssot.contrib import NautobotAdapter
 
 from {{ cookiecutter.app_name }}.diffsync.models import DeviceSSoTModel
 


### PR DESCRIPTION
## What's Changed

- Fixed `NameError: name 'NautobotAdapter' is not defined` on `invoke makemigrations`, experienced as below:

```
Congratulations! Your cookie has now been baked. It is located at <SNIP>

⚠️⚠️ Before you start using your cookie you must run the following commands inside your cookie:

* poetry lock
* poetry install
* poetry shell
* invoke makemigrations
* invoke ruff --fix # this will ensure all python files are formatted correctly, may require `sudo chown -R $USER ./` as migrations may be owned by root

Note: The file `development/creds.env` may be automatically created and ignored by git. It can be used to override default environment variables within the docker containers.
```
but:
```
<SNIP>$ invoke makemigrations
⚠️⚠️ The creds.env file does not exist, using the example file to create it. ⚠️⚠️
Running docker compose command "ps --services --filter status=running"
Running docker compose command "run --rm --entrypoint='nautobot-server makemigrations <SNIP>' nautobot"
[+] Running 11/11
...
Traceback (most recent call last):
  File "/usr/local/bin/nautobot-server", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/nautobot/core/cli/__init__.py", line 293, in main
    execute_from_command_line([sys.argv[0], *unparsed_args])
  File "/usr/local/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.11/site-packages/django/core/management/__init__.py", line 416, in execute
    django.setup()
  File "/usr/local/lib/python3.11/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python3.11/site-packages/django/apps/registry.py", line 124, in populate
    app_config.ready()
  File "/usr/local/lib/python3.11/site-packages/nautobot/extras/plugins/__init__.py", line 146, in ready
    jobs = import_object(f"{self.__module__}.{self.jobs}")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/nautobot/extras/plugins/utils.py", line 46, in import_object
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/source/<SNIP>/jobs.py", line 6, in <module>
    from <SNIP>.diffsync.adapters import <SNIP>, <SNIP><SNIP>
  File "/source/<SNIP>/diffsync/adapters.py", line 33, in <module>
    class <SNIP>(NautobotAdapter):
                                   ^^^^^^^^^^^^^^^
NameError: name 'NautobotAdapter' is not defined
```