### PR TITLE
Implement djlint for django template linting and formatting

### DIFF
--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -42,6 +42,19 @@ jobs:
           poetry-version: "2.1.3"
       - name: "Linting: ruff"
         run: "poetry run invoke ruff --action lint"
+  djlint-format:
+    runs-on: "ubuntu-22.04"
+    env:
+      INVOKE_{{ cookiecutter.app_name.upper() }}_LOCAL: "True"
+    steps:
+      - name: "Check out repository code"
+        uses: "actions/checkout@v4"
+      - name: "Setup environment"
+        uses: "networktocode/gh-action-setup-poetry-environment@v6"
+        with:
+          poetry-version: "2.1.3"
+      - name: "Linting: djlint format"
+        run: "poetry run invoke djlint --action format"
   check-docs-build:
     runs-on: "ubuntu-22.04"
     env:

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/contributing.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/contributing.md
@@ -7,6 +7,7 @@ The project is following Network to Code software development guidelines and is 
 - Python linting and formatting: `pylint` and `ruff`.
 - YAML linting is done with `yamllint`.
 - Django unit test to ensure the app is working properly.
+- Django Template linting and formatting: `djlint`
 
 Documentation is built using [mkdocs](https://www.mkdocs.org/). The [Docker based development environment](dev_environment.md#docker-development-environment) automatically starts a container hosting a live version of the documentation website on [http://localhost:8001](http://localhost:8001) that auto-refreshes when you make any changes to your local files.
 

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/dev_environment.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/dev_environment.md
@@ -129,6 +129,7 @@ Each command can be executed with `invoke <command>`. All commands support the a
   markdownlint     Run pymarkdown linting.
   tests            Run all tests for this app.
   unittest         Run Django unit tests for the app.
+  djlint           Run djlint to perform django template formatting and/or linting.
 ```
 
 ## Project Overview

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -61,6 +61,7 @@ griffe = "1.1.1"
 towncrier = ">=23.6.0,<=24.8.0"
 to-json-schema = "*"
 jsonschema = "*"
+djlint = ">=1.36.4,<2.0.0"
 
 [tool.poetry.extras]
 all = [
@@ -207,3 +208,12 @@ showcontent = true
 directory = "housekeeping"
 name = "Housekeeping"
 showcontent = true
+
+[tool.djlint]
+ignore = "H005,H006,H008,H011,H012,H013,H014,H015,H016,H019,H020,H021,H022,H023,H025,H026,H030,H031,H037"
+max_line_length = 1000
+preserve_blank_lines = true
+max_attribute_length = 1000
+line_break_after_multiline_tag = false
+profile="django"
+extend_exclude = "docs/,{{ cookiecutter.app_name }}/static/"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -773,6 +773,7 @@ def pylint(context):
 def autoformat(context):
     """Run code autoformatting."""
     ruff(context, action=["format"], fix=True)
+    djlint(context, action=["format"], fix=True)
 
 
 @task(
@@ -810,6 +811,39 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         if not run_command(context, command, warn=True):
             exit_code = 1
 
+    if exit_code != 0:
+        raise Exit(code=exit_code)
+
+
+@task(
+    help={
+        "action": "Available values are `['lint', 'format']`. Can be used multiple times. (default: `['lint', 'format']`)",
+        "target": "File or directory to inspect, repeatable (default: all files in the project will be inspected)",
+        "fix": "Automatically fix the formatting. (default: False)",
+        "quiet": "Do not print diff when formatting or checking (default: False)",
+    },
+    iterable=["target", "action"],
+)
+def djlint(context, action=None, target=None, fix=False, quiet=False):
+    """Run djlint to validate Django template formatting."""
+    if not action:
+        action = ["format"]  # TODO: Add 'lint' when we are ready to enforce linting
+    if not target:
+        target = ["."]
+
+    command = "djlint "
+
+    if "format" in action:
+        command += "--reformat --warn " if fix else "--check "
+        if quiet:
+            command += "--quiet "
+
+    if "lint" in action:
+        command += "--lint "
+
+    command += " ".join(target)
+
+    exit_code = 0 if run_command(context, command, warn=True) else 1
     if exit_code != 0:
         raise Exit(code=exit_code)
 
@@ -930,6 +964,8 @@ def tests(context, failfast=False, keepdb=False, lint_only=False):
     # Sorted loosely from fastest to slowest
     print("Running ruff...")
     ruff(context)
+    print("Running djlint...")
+    djlint(context)
     print("Running yamllint...")
     yamllint(context)
     print("Running markdownlint...")


### PR DESCRIPTION
## What's Changed

Implement djlint for django template linting and formatting. Currently the CI will only enforce formatting until we can validate the linter rules we want to enforce.

## To Do

- [ ] Update the documentation.
- [ ] Add changelog.
