### PR TITLE
Release nautobot-app-v2.6.0

### DIFF
--- a/docs/admin/release_notes/version_2.5.md
+++ b/docs/admin/release_notes/version_2.5.md
@@ -1,4 +1,4 @@
-# v2.4 Release Notes
+# v2.5 Release Notes
 
 This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/docs/admin/release_notes/version_2.6.md
+++ b/docs/admin/release_notes/version_2.6.md
@@ -1,0 +1,38 @@
+# v2.6 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Added Nautobot component UI framework example.
+- Changed minimum Nautobot version to `2.4.2`.
+- Updated Poetry to v2.
+
+## [v2.6.0 (2025-09-16)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/v2.6.0)
+
+### Added
+
+- [#270](https://github.com/nautobot/cookiecutter-nautobot-app/issues/270) - Added UI Component Framework example.
+- [#270](https://github.com/nautobot/cookiecutter-nautobot-app/issues/270) - Added Global variable for `min_nautobot_version` and `max_nautobot_version`.
+- [#278](https://github.com/nautobot/cookiecutter-nautobot-app/issues/278) - Added searchable models to AppConfig.
+- [#259](https://github.com/nautobot/cookiecutter-nautobot-app/issues/259) - Enabled front-matter extension for pymarkdown.
+- [#266](https://github.com/nautobot/cookiecutter-nautobot-app/issues/266) - Enabled pymarkdown `selectively_enable_rules` configuration.
+- [#271](https://github.com/nautobot/cookiecutter-nautobot-app/issues/271) - Updated Poetry from `1.8.5` to `2.1.3`.
+- [#281](https://github.com/nautobot/cookiecutter-nautobot-app/issues/281) - Added djlint for django template linting.
+- [#283](https://github.com/nautobot/cookiecutter-nautobot-app/issues/283) - Added `pymdownx.details` markdown extension to mkdocs.yml.
+- [#285](https://github.com/nautobot/cookiecutter-nautobot-app/issues/285) - Added DjHTML for Django template formatting.
+
+### Changed
+
+- [#270](https://github.com/nautobot/cookiecutter-nautobot-app/issues/270) - Changed default minimum nautobot version to `2.4.2`.
+- [#283](https://github.com/nautobot/cookiecutter-nautobot-app/issues/283) - Updated readthedocs config to use poetry and removed `docs/requirements.txt`.
+- [#283](https://github.com/nautobot/cookiecutter-nautobot-app/issues/283) - Changed `SLACK_WEBHOOK_URL` secret to `OSS_PYPI_SLACK_WEBHOOK_URL`.
+- [#283](https://github.com/nautobot/cookiecutter-nautobot-app/issues/283) - Updated github actions runners to use ubuntu-latest.
+- [#283](https://github.com/nautobot/cookiecutter-nautobot-app/issues/283) - Updated charfields max_length to use nautobot.apps.constants.CHARFIELD_MAX_LENGTH.
+- [#284](https://github.com/nautobot/cookiecutter-nautobot-app/issues/284) - Added support for python patch version in `invoke lock --constrain-python-ver`.
+- [#284](https://github.com/nautobot/cookiecutter-nautobot-app/issues/287) - Disabled pylint rules `too-many-positional-arguments`, `nb-warn-dunder-filter-field`, `nb-no-search-function`, and `nb-no-char-filter-q`.
+
+### Removed
+
+- [#270](https://github.com/nautobot/cookiecutter-nautobot-app/issues/270) - Removed `min_nautobot_version` and `max_nautobot_version` from inputs.
+- [#270](https://github.com/nautobot/cookiecutter-nautobot-app/issues/270) - Removed deprecated `min_nautobot_version` and `max_nautobot_version` from AppConfig.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v2.6: "admin/release_notes/version_2.6.md"
           - v2.5: "admin/release_notes/version_2.5.md"
           - v2.4: "admin/release_notes/version_2.4.md"
           - v2.3: "admin/release_notes/version_2.3.md"


### PR DESCRIPTION
# v2.6 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

- Added Nautobot component UI framework example.
- Changed minimum Nautobot version to `2.4.2`.
- Updated Poetry to v2.

## [v2.6.0 (2025-09-16)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/v2.6.0)

### Added

- [#270](https://github.com/nautobot/cookiecutter-nautobot-app/issues/270) - Added UI Component Framework example.
- [#270](https://github.com/nautobot/cookiecutter-nautobot-app/issues/270) - Added Global variable for `min_nautobot_version` and `max_nautobot_version`.
- [#278](https://github.com/nautobot/cookiecutter-nautobot-app/issues/278) - Added searchable models to AppConfig.
- [#259](https://github.com/nautobot/cookiecutter-nautobot-app/issues/259) - Enabled front-matter extension for pymarkdown.
- [#266](https://github.com/nautobot/cookiecutter-nautobot-app/issues/266) - Enabled pymarkdown `selectively_enable_rules` configuration.
- [#271](https://github.com/nautobot/cookiecutter-nautobot-app/issues/271) - Updated Poetry from `1.8.5` to `2.1.3`.
- [#281](https://github.com/nautobot/cookiecutter-nautobot-app/issues/281) - Added djlint for django template linting.
- [#283](https://github.com/nautobot/cookiecutter-nautobot-app/issues/283) - Added `pymdownx.details` markdown extension to mkdocs.yml.
- [#285](https://github.com/nautobot/cookiecutter-nautobot-app/issues/285) - Added DjHTML for Django template formatting.

### Changed

- [#270](https://github.com/nautobot/cookiecutter-nautobot-app/issues/270) - Changed default minimum nautobot version to `2.4.2`.
- [#283](https://github.com/nautobot/cookiecutter-nautobot-app/issues/283) - Updated readthedocs config to use poetry and removed `docs/requirements.txt`.
- [#283](https://github.com/nautobot/cookiecutter-nautobot-app/issues/283) - Changed `SLACK_WEBHOOK_URL` secret to `OSS_PYPI_SLACK_WEBHOOK_URL`.
- [#283](https://github.com/nautobot/cookiecutter-nautobot-app/issues/283) - Updated github actions runners to use ubuntu-latest.
- [#283](https://github.com/nautobot/cookiecutter-nautobot-app/issues/283) - Updated charfields max_length to use nautobot.apps.constants.CHARFIELD_MAX_LENGTH.
- [#284](https://github.com/nautobot/cookiecutter-nautobot-app/issues/284) - Added support for python patch version in `invoke lock --constrain-python-ver`.
- [#284](https://github.com/nautobot/cookiecutter-nautobot-app/issues/287) - Disabled pylint rules `too-many-positional-arguments`, `nb-warn-dunder-filter-field`, `nb-no-search-function`, and `nb-no-char-filter-q`.

### Removed

- [#270](https://github.com/nautobot/cookiecutter-nautobot-app/issues/270) - Removed `min_nautobot_version` and `max_nautobot_version` from inputs.
- [#270](https://github.com/nautobot/cookiecutter-nautobot-app/issues/270) - Removed deprecated `min_nautobot_version` and `max_nautobot_version` from AppConfig.
