### PR TITLE
Release v2.7.1

### DIFF
--- a/changes/303.fixed
+++ b/changes/303.fixed
@@ -1,1 +1,0 @@
-Fixed release workflow missing the docs build step.

--- a/docs/admin/release_notes/version_2.7.md
+++ b/docs/admin/release_notes/version_2.7.md
@@ -10,6 +10,12 @@ This document describes all new features and changes in the release. The format 
 - Added support for PyPI Trusted Publisher in release workflow.
 
 <!-- towncrier release notes start -->
+## [nautobot-app-v2.7.1 (2025-10-30)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v2.7.1)
+
+### Fixed
+
+- [#303](https://github.com/nautobot/cookiecutter-nautobot-app/issues/303) - Fixed release workflow missing the docs build step.
+
 ## [nautobot-app-v2.7.0 (2025-10-23)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v2.7.0)
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ plugins.list-anchored-indent.enabled = true
 
 [tool.towncrier]
 directory = "changes"
-filename = "docs/admin/release_notes/version_2.6.md"
+filename = "docs/admin/release_notes/version_2.7.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/cookiecutter-nautobot-app/issues/{issue})"


### PR DESCRIPTION
## [nautobot-app-v2.7.1 (2025-10-30)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v2.7.1)

### Fixed

- [#303](https://github.com/nautobot/cookiecutter-nautobot-app/issues/303) - Fixed release workflow missing the docs build step.

