### PR TITLE
main-to-develop

### DIFF
--- a/changes/319.documentation
+++ b/changes/319.documentation
@@ -1,0 +1,1 @@
+Fixed nav typo and added missing 2.7.2 release notes.

--- a/docs/admin/release_notes/version_2.7.md
+++ b/docs/admin/release_notes/version_2.7.md
@@ -10,6 +10,12 @@ This document describes all new features and changes in the release. The format 
 - Added support for PyPI Trusted Publisher in release workflow.
 
 <!-- towncrier release notes start -->
+## [nautobot-app-v2.7.2 (2025-12-02)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v2.7.2)
+
+### Fixed
+
+- [#310](https://github.com/nautobot/cookiecutter-nautobot-app/issues/310) - Fixed version numbers in ltm-2.4 branch.
+
 ## [nautobot-app-v2.7.1 (2025-10-30)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v2.7.1)
 
 ### Fixed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,7 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
-          - v2.6: "admin/release_notes/version_2.7.md"
+          - v2.7: "admin/release_notes/version_2.7.md"
           - v2.6: "admin/release_notes/version_2.6.md"
           - v2.5: "admin/release_notes/version_2.5.md"
           - v2.4: "admin/release_notes/version_2.4.md"


### PR DESCRIPTION
Cookiecutter main-to-develop. Capture 2.7 release notes fix.
