### PR TITLE
Changed invoke docker service kwarg to be an iterable

### DIFF
--- a/changes/328.changed
+++ b/changes/328.changed
@@ -1,1 +1,1 @@
-Changed invoke `start`, `restart`, `stop`, and `logs` commands to accept multiple services as arguments.
+Changed invoke `start`, `restart`, `stop`, `debug`, and `logs` commands to accept multiple services as arguments.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -288,34 +288,35 @@ def lock(context, check=False, constrain_nautobot_ver=False, constrain_python_ve
 # ------------------------------------------------------------------------------
 # START / STOP / DEBUG
 # ------------------------------------------------------------------------------
-@task(help={"service": "If specified, only affect this service."})
-def debug(context, service=""):
+@task(help={"service": "If specified, only affect the specified service(s); can be provided multiple times (i.e. -s nautobot -s worker)."}, iterable=["service"])
+def debug(context, service=None):
     """Start specified or all services and its dependencies in debug mode."""
-    print(f"Starting {service} in debug mode...")
+    service = " ".join(service) if service else ""
+    print(f"Starting {service or 'all services'} in debug mode...")
     docker_compose(context, "up", service=service)
 
 
 @task(help={"service": "If specified, only affect the specified service(s); can be provided multiple times (i.e. -s nautobot -s worker)."}, iterable=["service"])
 def start(context, service=None):
     """Start specified service(s) or all services and its dependencies in detached mode."""
-    print("Starting Nautobot in detached mode...")
-    service = " ".join(service) if service else None
+    service = " ".join(service) if service else ""
+    print(f"Starting {service or 'all services'} in detached mode...")
     docker_compose(context, "up --detach", service=service)
 
 
 @task(help={"service": "If specified, only affect the specified service(s); can be provided multiple times (i.e. -s nautobot -s worker)."}, iterable=["service"])
 def restart(context, service=None):
     """Gracefully restart specified or all services."""
-    print("Restarting Nautobot...")
-    service = " ".join(service) if service else None
+    service = " ".join(service) if service else ""
+    print(f"Restarting {service or 'all services'}...")
     docker_compose(context, "restart", service=service)
 
 
 @task(help={"service": "If specified, only affect the specified service(s); can be provided multiple times (i.e. -s nautobot -s worker)."}, iterable=["service"])
 def stop(context, service=None):
     """Stop specified or all services, if service is not specified, remove all containers."""
-    print("Stopping Nautobot...")
-    service = " ".join(service) if service else None
+    service = " ".join(service) if service else ""
+    print(f"Stopping {service or 'all services'}...")
     docker_compose(context, "stop" if service else "down --remove-orphans", service=service)
 
 


### PR DESCRIPTION
# Closes #DNE

## What's Changed

This PR changes the `service` option for a couple invoke commands to be an iterable. This allows the user to provide multiple services rather than be limited to either a single service or all.

I have added this to the following commands:
- invoke start
- invoke stop
- invoke restart
- invoke logs

## To Do

- [x] Add changelog.
