### PR TITLE
Release v3.1.2

### DIFF
--- a/changes/359.fixed
+++ b/changes/359.fixed
@@ -1,0 +1,1 @@
+Fixed glightbox dependency.

--- a/changes/359.fixed
+++ b/changes/359.fixed
@@ -1,1 +1,0 @@
-Fixed glightbox dependency.

--- a/docs/admin/release_notes/version_3.1.md
+++ b/docs/admin/release_notes/version_3.1.md
@@ -7,6 +7,12 @@ This document describes all new features and changes in the release. The format 
 - Added support for Python `3.14`.
 
 <!-- towncrier release notes start -->
+## [nautobot-app-v3.1.2 (2026-03-10)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v3.1.2)
+
+### Fixed
+
+- [#359](https://github.com/nautobot/cookiecutter-nautobot-app/issues/359) - Fixed glightbox dependency.
+
 ## [nautobot-app-v3.1.1 (2026-03-10)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v3.1.1)
 
 ### Added

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -71,7 +71,8 @@ mkdocstrings = "0.25.2"
 mkdocstrings-python = "1.10.8"
 mkdocs-autorefs = "1.2.0"
 griffe = "1.1.1"
-glightbox = "3.2.0"
+# Image lightboxing in mkdocs
+mkdocs-glightbox = "~0.5.2"
 
 [tool.poetry.extras]
 all = [

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -68,7 +68,8 @@ mkdocstrings = "0.25.2"
 mkdocstrings-python = "1.10.8"
 mkdocs-autorefs = "1.2.0"
 griffe = "1.1.1"
-glightbox = "3.2.0"
+# Image lightboxing in mkdocs
+mkdocs-glightbox = "~0.5.2"
 
 [tool.poetry.extras]
 all = [

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -67,7 +67,8 @@ mkdocstrings = "0.25.2"
 mkdocstrings-python = "1.10.8"
 mkdocs-autorefs = "1.2.0"
 griffe = "1.1.1"
-glightbox = "3.2.0"
+# Image lightboxing in mkdocs
+mkdocs-glightbox = "~0.5.2"
 
 [tool.poetry.extras]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ plugins.list-anchored-indent.enabled = true
 
 [tool.towncrier]
 directory = "changes"
-filename = "docs/admin/release_notes/version_3.0.md"
+filename = "docs/admin/release_notes/version_3.1.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/cookiecutter-nautobot-app/issues/{issue})"


### PR DESCRIPTION
## [nautobot-app-v3.1.2 (2026-03-10)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v3.1.2)

### Fixed

- [#359](https://github.com/nautobot/cookiecutter-nautobot-app/issues/359) - Fixed glightbox dependency.
