### PR TITLE
Release nautobot-app-v3.1.3

### DIFF
--- a/changes/364.housekeeping
+++ b/changes/364.housekeeping
@@ -1,1 +1,0 @@
-Fixed the logo in the footer of the documentation.

--- a/changes/364.housekeeping
+++ b/changes/364.housekeeping
@@ -1,0 +1,1 @@
+Fixed the logo in the footer of the documentation.

--- a/docs/admin/release_notes/version_3.1.md
+++ b/docs/admin/release_notes/version_3.1.md
@@ -7,6 +7,13 @@ This document describes all new features and changes in the release. The format 
 - Added support for Python `3.14`.
 
 <!-- towncrier release notes start -->
+
+## [nautobot-app-v3.1.3 (2026-04-09)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v3.1.3)
+
+### Housekeeping
+
+- [#364](https://github.com/nautobot/cookiecutter-nautobot-app/issues/364) - Fixed the logo in the footer of the documentation.
+
 ## [nautobot-app-v3.1.2 (2026-03-10)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v3.1.2)
 
 ### Fixed

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -51,9 +51,15 @@ img.logo {
     height: 200px;
 }
 
+a.copyright-sponsor {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    vertical-align: middle;
+}
+
 img.copyright-logo {
     height: 24px;
-    vertical-align: middle;
 }
 
 [data-md-color-primary=black] .md-header {

--- a/docs/assets/overrides/partials/copyright.html
+++ b/docs/assets/overrides/partials/copyright.html
@@ -12,8 +12,8 @@
         MkDocs</a>
     | <a href="https://www.networktocode.com/community/open-source/" target="_blank" rel="noopener">Join #Nautobot on the Network to Code Slack</a>
     {% if config.extra.ntc_sponsor == true %}
-    | <a href="https://networktocode.com" target="_blank" rel="noopener">Sponsored by <img
-            src={{ "assets/networktocode_bw.png" | url }} class="copyright-logo" alt="Network to Code" width="660" height="100"></a>
+    | <a href="https://networktocode.com" target="_blank" rel="noopener" class="copyright-sponsor">Sponsored by <img
+        src={{ "assets/networktocode_bw.png" | url }} class="copyright-logo" alt="Network to Code" width="auto" height="auto"></a>
     {% endif %}
 </div>
 

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/assets/extra.css
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/assets/extra.css
@@ -51,9 +51,15 @@ img.logo {
     height: 200px;
 }
 
+a.copyright-sponsor {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    vertical-align: middle;
+}
+
 img.copyright-logo {
     height: 24px;
-    vertical-align: middle;
 }
 
 [data-md-color-primary=black] .md-header {

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/assets/overrides/partials/copyright.html
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/assets/overrides/partials/copyright.html
@@ -12,8 +12,8 @@
     <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">Made with Material for MkDocs</a>
     | <a href="https://www.networktocode.com/community/open-source/" target="_blank" rel="noopener">Join #Nautobot on the Network to Code Slack</a>
     {% if config.extra.ntc_sponsor == true %}
-    | <a href="https://networktocode.com" target="_blank" rel="noopener">Sponsored by <img
-            src={{ "assets/networktocode_bw.png" | url }} class="copyright-logo" alt="Network to Code" width="660" height="100"></a>
+    | <a href="https://networktocode.com" target="_blank" rel="noopener" class="copyright-sponsor">Sponsored by <img
+        src={{ "assets/networktocode_bw.png" | url }} class="copyright-logo" alt="Network to Code" width="auto" height="auto"></a>
     {% endif %}
 </div>
 


### PR DESCRIPTION
## [nautobot-app-v3.1.3 (2026-04-09)](https://github.com/nautobot/cookiecutter-nautobot-app/releases/tag/nautobot-app-v3.1.3)

### Housekeeping

- [#364](https://github.com/nautobot/cookiecutter-nautobot-app/issues/364) - Fixed the logo in the footer of the documentation.