### PR TITLE
Closes #373: Added 'target' and 'recursive' options to 'invoke pylint'

### DIFF
--- a/changes/373.changed
+++ b/changes/373.changed
@@ -1,0 +1,1 @@
+Added `target` and `recursive` options to `invoke pylint` tasks.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -780,26 +780,49 @@ def hadolint(context):
     run_command(context, command)
 
 
-@task
-def pylint(context):
+@task(
+    help={
+        "target": "Module or file or directory to inspect, repeatable (default: app package)",
+        "recursive": "Must be set if target is a directory rather than a module or file name",
+    },
+    iterable=["target"],
+)
+def pylint(context, target=None, recursive=False):
     """Run pylint code analysis."""
     exit_code = 0
 
     base_pylint_command = 'pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml'
-    command = f"{base_pylint_command} {{ cookiecutter.app_name }}"
+    command = base_pylint_command
+    if recursive:
+        command += " --recursive=y"
+    command += f" {' '.join(target) if target else '{{ cookiecutter.app_name }}'}"
     if not run_command(context, command, warn=True):
         exit_code = 1
 
     # run the pylint_django migrations checkers on the migrations directory, if one exists
-    migrations_dir = Path(__file__).absolute().parent / Path("{{ cookiecutter.app_name }}") / Path("migrations")
+    app_dir = Path(__file__).absolute().parent / Path("{{ cookiecutter.app_name }}")
+    migrations_dir = app_dir / Path("migrations")
+    migrations_target_module = "{{ cookiecutter.app_name }}.migrations"
+    run_migrations_check = target is None
+    if target is not None:
+        for target_item in target:
+            target_item_normalized = Path(target_item).resolve()
+            if (
+                target_item_normalized in (app_dir, migrations_dir)
+                or target_item == migrations_target_module
+            ):
+                run_migrations_check = True
+                break
+
     if migrations_dir.is_dir():
-        migrations_pylint_command = (
-            f"{base_pylint_command} --load-plugins=pylint_django.checkers.migrations"
-            " --disable=all --enable=fatal,new-db-field-with-default,missing-backwards-migration-callable"
-            " {{ cookiecutter.app_name }}.migrations"
-        )
-        if not run_command(context, migrations_pylint_command, warn=True):
-            exit_code = 1
+        if run_migrations_check:
+            migrations_pylint_command = (
+                f"{base_pylint_command} --load-plugins=pylint_django.checkers.migrations"
+                " --disable=all --enable=fatal,new-db-field-with-default,missing-backwards-migration-callable"
+                " {{ cookiecutter.app_name }}.migrations"
+            )
+            if not run_command(context, migrations_pylint_command, warn=True):
+                exit_code = 1
     else:
         print("No migrations directory found, skipping migrations checks.")
 

--- a/tasks.py
+++ b/tasks.py
@@ -339,10 +339,19 @@ def generate_release_notes(context, version):
 # ------------------------------------------------------------------
 # TESTS
 # ------------------------------------------------------------------------------
-@task
-def pylint(context):
+@task(
+    help={
+        "target": "Module or file or directory to inspect, repeatable (default: project python files and template tests)",
+        "recursive": "Must be set if target is a directory rather than a module or file name",
+    },
+    iterable=["target"],
+)
+def pylint(context, target=None, recursive=False):
     """Run pylint code analysis."""
-    command = f"pylint --rcfile pyproject.toml {collect_files(context)}"
+    command = "pylint --rcfile pyproject.toml "
+    if recursive:
+        command += "--recursive=y "
+    command += " ".join(target) if target else collect_files(context)
     run_command(context, command)
 
 


### PR DESCRIPTION
# Closes #373

## What's Changed

- Added `target` and `recursive` options to `invoke pylint` tasks
- Updated the guard around the migrations check so it's only invoked if the target is unset or set to the app directory or app_directory/migrations


## Sample output

### No arguments

```
% invoke pylint
Running docker compose command "ps --services --filter status=running"
Running docker compose command "run --rm --entrypoint='pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml nautobot_dev_example' nautobot"
[+]  2/2t 2/22

[container status]


15:32:00.741 INFO    nautobot             __init__.py                              setup() : Nautobot 3.0.0 initialized!
Using config file pyproject.toml
Get ASTs.
AST for nautobot_dev_example/__init__.py
AST for nautobot_dev_example/models.py
AST for nautobot_dev_example/forms.py
AST for nautobot_dev_example/tables.py
AST for nautobot_dev_example/navigation.py
AST for nautobot_dev_example/urls.py
AST for nautobot_dev_example/filters.py
AST for nautobot_dev_example/views.py
AST for nautobot_dev_example/tests/test_forms.py
AST for nautobot_dev_example/tests/__init__.py
AST for nautobot_dev_example/tests/test_views.py
AST for nautobot_dev_example/tests/test_models.py
AST for nautobot_dev_example/tests/test_api.py
AST for nautobot_dev_example/tests/test_filters.py
AST for nautobot_dev_example/tests/fixtures.py
AST for nautobot_dev_example/api/serializers.py
AST for nautobot_dev_example/api/__init__.py
AST for nautobot_dev_example/api/urls.py
AST for nautobot_dev_example/api/views.py
Linting 19 modules.
nautobot_dev_example/__init__.py (1 of 19)
nautobot_dev_example/models.py (2 of 19)
nautobot_dev_example/forms.py (3 of 19)
nautobot_dev_example/tables.py (4 of 19)
nautobot_dev_example/navigation.py (5 of 19)
nautobot_dev_example/urls.py (6 of 19)
nautobot_dev_example/filters.py (7 of 19)
nautobot_dev_example/views.py (8 of 19)
nautobot_dev_example/tests/test_forms.py (9 of 19)
nautobot_dev_example/tests/__init__.py (10 of 19)
nautobot_dev_example/tests/test_views.py (11 of 19)
nautobot_dev_example/tests/test_models.py (12 of 19)
nautobot_dev_example/tests/test_api.py (13 of 19)
nautobot_dev_example/tests/test_filters.py (14 of 19)
nautobot_dev_example/tests/fixtures.py (15 of 19)
nautobot_dev_example/api/serializers.py (16 of 19)
nautobot_dev_example/api/__init__.py (17 of 19)
nautobot_dev_example/api/urls.py (18 of 19)
nautobot_dev_example/api/views.py (19 of 19)

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Your code has been rated at 10.00/10
Checked 19 files/modules (nautobot_dev_example/tables.py, nautobot_dev_example/views.py, nautobot_dev_example/api/serializers.py, nautobot_dev_example/api/views.py, nautobot_dev_example/tests/test_models.py, nautobot_dev_example/urls.py, nautobot_dev_example/tests/test_forms.py, nautobot_dev_example/__init__.py, nautobot_dev_example/filters.py, nautobot_dev_example/api/urls.py, nautobot_dev_example/tests/__init__.py, nautobot_dev_example/tests/fixtures.py, nautobot_dev_example/models.py, nautobot_dev_example/tests/test_views.py, nautobot_dev_example/tests/test_api.py, nautobot_dev_example/navigation.py, nautobot_dev_example/forms.py, nautobot_dev_example/api/__init__.py, nautobot_dev_example/tests/test_filters.py), skipped 0 files/modules
```

### -t operation, passed once

```
% invoke pylint -t nautobot_dev_example/tests
Running docker compose command "ps --services --filter status=running"
Running docker compose command "run --rm --entrypoint='pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml nautobot_dev_example/tests' nautobot"
[+]  2/2t 2/22

[container status]

15:30:45.192 INFO    nautobot             __init__.py                              setup() : Nautobot 3.0.0 initialized!
Using config file pyproject.toml
Get ASTs.
AST for nautobot_dev_example/tests/__init__.py
AST for nautobot_dev_example/tests/test_forms.py
AST for nautobot_dev_example/tests/test_views.py
AST for nautobot_dev_example/tests/test_models.py
AST for nautobot_dev_example/tests/test_api.py
AST for nautobot_dev_example/tests/test_filters.py
AST for nautobot_dev_example/tests/fixtures.py
Linting 7 modules.
nautobot_dev_example/tests/__init__.py (1 of 7)
nautobot_dev_example/tests/test_forms.py (2 of 7)
nautobot_dev_example/tests/test_views.py (3 of 7)
nautobot_dev_example/tests/test_models.py (4 of 7)
nautobot_dev_example/tests/test_api.py (5 of 7)
nautobot_dev_example/tests/test_filters.py (6 of 7)
nautobot_dev_example/tests/fixtures.py (7 of 7)
    version_major_minor = ".".join(version.split(".")[:2])

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Your code has been rated at 10.00/10
Checked 7 files/modules (nautobot_dev_example/tests/__init__.py, nautobot_dev_example/tests/fixtures.py, nautobot_dev_example/tests/test_views.py, nautobot_dev_example/tests/test_filters.py, nautobot_dev_example/tests/test_forms.py, nautobot_dev_example/tests/test_models.py, nautobot_dev_example/tests/test_api.py), skipped 0 files/modules
```

### -t operation, passed twice

```
invoke pylint -t nautobot_dev_example/tests -t nautobot_dev_example/api
Running docker compose command "ps --services --filter status=running"
Running docker compose command "run --rm --entrypoint='pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml nautobot_dev_example/tests nautobot_dev_example/api' nautobot"
[+]  2/2t 2/22

[container status]


15:30:20.966 INFO    nautobot             __init__.py                              setup() : Nautobot 3.0.0 initialized!
Using config file pyproject.toml
Get ASTs.
AST for nautobot_dev_example/tests/__init__.py
AST for nautobot_dev_example/tests/test_forms.py
AST for nautobot_dev_example/tests/test_views.py
AST for nautobot_dev_example/tests/test_models.py
AST for nautobot_dev_example/tests/test_api.py
AST for nautobot_dev_example/tests/test_filters.py
AST for nautobot_dev_example/tests/fixtures.py
AST for nautobot_dev_example/api/__init__.py
AST for nautobot_dev_example/api/serializers.py
AST for nautobot_dev_example/api/urls.py
AST for nautobot_dev_example/api/views.py
Linting 11 modules.
nautobot_dev_example/tests/__init__.py (1 of 11)
nautobot_dev_example/tests/test_forms.py (2 of 11)
nautobot_dev_example/tests/test_views.py (3 of 11)
nautobot_dev_example/tests/test_models.py (4 of 11)
nautobot_dev_example/tests/test_api.py (5 of 11)
nautobot_dev_example/tests/test_filters.py (6 of 11)
nautobot_dev_example/tests/fixtures.py (7 of 11)
nautobot_dev_example/api/__init__.py (8 of 11)
nautobot_dev_example/api/serializers.py (9 of 11)
nautobot_dev_example/api/urls.py (10 of 11)
nautobot_dev_example/api/views.py (11 of 11)

----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Your code has been rated at 10.00/10
Checked 11 files/modules (nautobot_dev_example/api/views.py, nautobot_dev_example/tests/test_models.py, nautobot_dev_example/tests/test_views.py, nautobot_dev_example/tests/test_forms.py, nautobot_dev_example/tests/test_filters.py, nautobot_dev_example/tests/test_api.py, nautobot_dev_example/tests/__init__.py, nautobot_dev_example/api/serializers.py, nautobot_dev_example/api/__init__.py, nautobot_dev_example/tests/fixtures.py, nautobot_dev_example/api/urls.py), skipped 0 files/modules
```

### Migration checks
For the purposes of this output, I added some debugging statements to tasks.py to make it obvious what's going on. These debug statements to not appear in this PR. The debug statements were inserted thusly:

```
def pylint(context, target=None, recursive=False):
    """Run pylint code analysis."""
    exit_code = 0
    print("** DEBUG: Running pylint")

    [...]

    if migrations_dir.is_dir():
        if run_migrations_check:
            print(" ** DEBUG: Running migrations check")
```

...with the following results, where the item in brackets was the argument to `-t`:

```
Testing [development]
=====================
** DEBUG: Running pylint

Testing [nautobot_dev_example/tests]
====================================
** DEBUG: Running pylint

Testing [nautobot_dev_example/]
===============================
** DEBUG: Running pylint
** DEBUG: Running migrations check

Testing [nautobot_dev_example]
==============================
** DEBUG: Running pylint
** DEBUG: Running migrations check

Testing [nautobot_dev_example/migrations/]
==========================================
** DEBUG: Running pylint
** DEBUG: Running migrations check

Testing [nautobot_dev_example/migrations]
=========================================
** DEBUG: Running pylint
** DEBUG: Running migrations check

Testing [nautobot_dev_example/../nautobot_dev_example/]
=======================================================
** DEBUG: Running pylint
** DEBUG: Running migrations check

Testing [nautobot_dev_example/../nautobot_dev_example/migrations]
=================================================================
** DEBUG: Running pylint
** DEBUG: Running migrations check

Testing [nautobot_dev_example.migrations]
=========================================
** DEBUG: Running pylint
** DEBUG: Running migrations check
```

The results were identical when running `-t docs -t <arg>`.


## To Do

- [ ] Update the documentation.
- [x] Add changelog.
- [x] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
