### PR TITLE
Closes #318: Added --diff option to 'invoke ruff' tasks

### DIFF
--- a/changes/318.changed
+++ b/changes/318.changed
@@ -1,0 +1,1 @@
+Added a `--diff` option to the `invoke ruff` tasks.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -824,7 +824,7 @@ def autoformat(context):
     },
     iterable=["action", "target"],
 )
-def ruff(context, action=None, target=None, fix=False, diff=False, output_format="concise"):
+def ruff(context, action=None, target=None, fix=False, diff=False, output_format="concise"):  # noqa: PLR0913
     """Run ruff to perform code formatting and/or linting."""
     if not action:
         action = ["lint", "format"]

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -819,11 +819,12 @@ def autoformat(context):
         "action": "Available values are `['lint', 'format']`. Can be used multiple times. (default: `--action lint --action format`)",
         "target": "File or directory to inspect, repeatable (default: all files in the project will be inspected)",
         "fix": "Automatically fix selected actions. May not be able to fix all issues found. (default: False)",
+        "diff": "Show diffs of changes. (default: False)",
         "output_format": "See https://docs.astral.sh/ruff/settings/#output-format for details. (default: `concise`)",
     },
     iterable=["action", "target"],
 )
-def ruff(context, action=None, target=None, fix=False, output_format="concise"):
+def ruff(context, action=None, target=None, fix=False, diff=False, output_format="concise"):
     """Run ruff to perform code formatting and/or linting."""
     if not action:
         action = ["lint", "format"]
@@ -836,6 +837,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         command = "ruff format "
         if not fix:
             command += "--check "
+            if diff:
+                command += "--diff "
         command += " ".join(target)
         if not run_command(context, command, warn=True):
             exit_code = 1
@@ -844,6 +847,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         command = "ruff check "
         if fix:
             command += "--fix "
+        elif diff:
+            command += "--diff "
         command += f"--output-format {output_format} "
         command += " ".join(target)
         if not run_command(context, command, warn=True):

--- a/tasks.py
+++ b/tasks.py
@@ -357,11 +357,12 @@ def autoformat(context):
         "action": "Available values are `['lint', 'format']`. Can be used multiple times. (default: `['lint', 'format']`)",
         "target": "File or directory to inspect, repeatable (default: all files in the project will be inspected)",
         "fix": "Automatically fix selected actions. May not be able to fix all issues found. (default: False)",
+        "diff": "Show diffs of changes. (default: False)",
         "output_format": "See https://docs.astral.sh/ruff/settings/#output-format for details. (default: `concise`)",
     },
     iterable=["action", "target"],
 )
-def ruff(context, action=None, target=None, fix=False, output_format="concise"):
+def ruff(context, action=None, target=None, fix=False, diff=False, output_format="concise"):
     """Run ruff to perform code formatting and/or linting."""
     if not action:
         action = ["lint", "format"]
@@ -374,6 +375,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         command = "ruff format "
         if not fix:
             command += "--check "
+            if diff:
+                command += "--diff "
         command += " ".join(target)
         if not run_command(context, command, warn=True):
             exit_code = 1
@@ -382,6 +385,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         command = "ruff check "
         if fix:
             command += "--fix "
+        elif diff:
+            command += "--diff "
         command += f"--output-format {output_format} "
         command += " ".join(target)
         if not run_command(context, command, warn=True):

--- a/tasks.py
+++ b/tasks.py
@@ -362,7 +362,7 @@ def autoformat(context):
     },
     iterable=["action", "target"],
 )
-def ruff(context, action=None, target=None, fix=False, diff=False, output_format="concise"):
+def ruff(context, action=None, target=None, fix=False, diff=False, output_format="concise"):  # noqa: PLR0913
     """Run ruff to perform code formatting and/or linting."""
     if not action:
         action = ["lint", "format"]


### PR DESCRIPTION
# Closes #318
## What's Changed

- Added a `--diff` option to the `invoke ruff` task in both the repository and generated app templates.

## Sample output

## `--diff` with no target
```
% invoke ruff --diff
Running docker compose command "ps --services --filter status=running"
Running docker compose command "run --rm --entrypoint='ruff format --check --diff .' nautobot"
[+]  2/2t 2/22

[container status]
```
```diff
--- nautobot_dev_example/models.py
+++ nautobot_dev_example/models.py
@@ -17,8 +17,7 @@
     """Base model for Nautobot Dev Example App app."""

     name = models.CharField(max_length=CHARFIELD_MAX_LENGTH, unique=True)
-    description = models.CharField(
-        max_length=CHARFIELD_MAX_LENGTH, blank=True)
+    description = models.CharField(max_length=CHARFIELD_MAX_LENGTH, blank=True)
     # additional model fields

     class Meta:
```

```diff
--- nautobot_dev_example/models.py
+++ nautobot_dev_example/models.py
@@ -2,10 +2,10 @@

 # Django imports
 from django.db import models
+from nautobot.apps.constants import CHARFIELD_MAX_LENGTH

 # Nautobot imports
 from nautobot.apps.models import PrimaryModel, extras_features
-from nautobot.apps.constants import CHARFIELD_MAX_LENGTH


 # If you want to choose a specific model to overload in your class declaration, please reference the following documentation:
```

### `--diff` with `--action`

#### `--action lint`
```
% invoke ruff --action lint --diff
Running docker compose command "ps --services --filter status=running"
Running docker compose command "run --rm --entrypoint='ruff check --diff --output-format concise .' nautobot"
[+]  2/2t 2/22

[container status]
```
```diff
--- nautobot_dev_example/models.py
+++ nautobot_dev_example/models.py
@@ -2,10 +2,10 @@

 # Django imports
 from django.db import models
+from nautobot.apps.constants import CHARFIELD_MAX_LENGTH

 # Nautobot imports
 from nautobot.apps.models import PrimaryModel, extras_features
-from nautobot.apps.constants import CHARFIELD_MAX_LENGTH
```

#### `--action format`
```
% invoke ruff --action format --diff
Running docker compose command "ps --services --filter status=running"
Running docker compose command "run --rm --entrypoint='ruff format --check --diff .' nautobot"
[+]  2/2t 2/22

[container status]
```
```diff
--- nautobot_dev_example/models.py
+++ nautobot_dev_example/models.py
@@ -17,8 +17,7 @@
     """Base model for Nautobot Dev Example App app."""

     name = models.CharField(max_length=CHARFIELD_MAX_LENGTH, unique=True)
-    description = models.CharField(
-        max_length=CHARFIELD_MAX_LENGTH, blank=True)
+    description = models.CharField(max_length=CHARFIELD_MAX_LENGTH, blank=True)
     # additional model fields

     class Meta:
```

## Notes
While running this repo's `invoke ruff`, `pty=True` is not passed to run_command, but running ruff on a dockerized project built from this repo will use `pty=True` without any changes. This means that while projects built from this repo can use `invoke ruff --diff` and expect colorized output, this repo itself will not get colorized output. Happy to add this to the base tasks.py if you'd like, I just wasn't sure if there were any unwanted side-effects from doing so.

## To Do

- [ ] Update the documentation.
- [x]  Add changelog.
- [x] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
