### PR TITLE
Added `--no-input` flag to `invoke unittest`

### DIFF
--- a/changes/376.added
+++ b/changes/376.added
@@ -1,0 +1,1 @@
+Added support for `--no-input` option to `invoke unittest` task.

--- a/changes/376.added
+++ b/changes/376.added
@@ -1,1 +1,1 @@
-Added support for `--no-input` option to `invoke unittest` task.
+Added support for `--no-input` option to `invoke unittest` and `invoke tests` tasks.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -997,10 +997,11 @@ def coverage_xml(context):
     help={
         "failfast": "fail as soon as a single test fails don't run the entire test suite. (default: False)",
         "keepdb": "Save and re-use test database between test runs for faster re-testing. (default: False)",
+        "no_input": "Suppress interactive prompts (e.g. confirmation when `--no-reusedb` would destroy an existing test database). (default: False)",
         "lint-only": "Only run linters; unit tests will be excluded. (default: False)",
     }
 )
-def tests(context, failfast=False, keepdb=False, lint_only=False):
+def tests(context, failfast=False, keepdb=False, no_input=False, lint_only=False):
     """Run all tests for this app."""
     # If we are not running locally, start the docker containers so we don't have to for each test
     if not is_truthy(context.{{ cookiecutter.app_name }}.local):
@@ -1027,7 +1028,7 @@ def tests(context, failfast=False, keepdb=False, lint_only=False):
     validate_app_config(context)
     if not lint_only:
         print("Running unit tests...")
-        unittest(context, failfast=failfast, keepdb=keepdb, coverage=True, skip_docs_build=True)
+        unittest(context, failfast=failfast, keepdb=keepdb, no_input=no_input, coverage=True, skip_docs_build=True)
         unittest_coverage(context)
         coverage_lcov(context)
     print("All tests have passed!")

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -929,6 +929,7 @@ def check_migrations(context):
         "pattern": "Run specific test methods, classes, or modules instead of all tests",
         "verbose": "Enable verbose test output.",
         "coverage": "Enable coverage reporting. Defaults to False",
+        "no_input": "Suppress interactive prompts (e.g. confirmation when `--no-reusedb` would destroy an existing test database).",
         "skip_docs_build": "Skip building the documentation before running tests.",
     }
 )
@@ -941,6 +942,7 @@ def unittest(  # noqa: PLR0913
     pattern="",
     verbose=False,
     coverage=False,
+    no_input=False,
     skip_docs_build=False,
 ):
     """Run Nautobot unit tests."""
@@ -961,6 +963,8 @@ def unittest(  # noqa: PLR0913
         command += f" -k='{pattern}'"
     if verbose:
         command += " --verbosity 2"
+    if no_input:
+        command += " --no-input"
 
     run_command(context, command)
 


### PR DESCRIPTION
# Closes #376

## What's Changed

Added `--no-input` flag to `invoke unittest`

## To Do

- [x] Add changelog.

This change has already been applied and tested in Nautobot Core via https://github.com/nautobot/nautobot/pull/8925
