### PR TITLE
NAPPS-1164 | Post-Release Version Bumps on develop, main, next, and ltm-

### DIFF
--- a/changes/381.fixed
+++ b/changes/381.fixed
@@ -1,0 +1,1 @@
+Updates the CI pipeline so that we auto increment post-release versions when creating a release from main, develop, next, and ltm-

--- a/changes/381.fixed
+++ b/changes/381.fixed
@@ -1,1 +1,1 @@
-Updates the CI pipeline so that we auto increment post-release versions when creating a release from main, develop, next, and ltm-
+Updated the CI pipeline so that we auto increment post-release versions when creating a release from main, develop, next, and ltm-*.

--- a/changes/381.fixes
+++ b/changes/381.fixes
@@ -1,1 +1,0 @@
-Updates the CI pipeline so that we auto increment post-release versions when creating a release from main, develop, next, and ltm-

--- a/changes/381.fixes
+++ b/changes/381.fixes
@@ -1,0 +1,1 @@
+Updates the CI pipeline so that we auto increment post-release versions when creating a release from main, develop, next, and ltm-

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
@@ -105,21 +105,21 @@ jobs:
               ]
             }
 
-  create-pr-to-develop:
-    if: "github.event.release.target_commitish == 'main'"
+  create-post-release-pr:
+    if: "contains(fromJSON('[\"main\", \"develop\"]'), github.event.release.target_commitish) || startsWith(github.event.release.target_commitish, 'next') || startsWith(github.event.release.target_commitish, 'ltm-')"
     permissions:
       contents: "write"
       pull-requests: "write"
-    name: "Create a PR from main into develop"
+    name: "{% raw %}${{ github.event.release.target_commitish == 'main' && 'Create a PR from main into develop' || format('Create a PR to merge into {0}', github.event.release.target_commitish) }}{% endraw %}"
     needs:
       - "publish-github"
       - "publish-pypi"
     runs-on: "ubuntu-latest"
     steps:
-      - name: "Checkout main"
+      - name: "Checkout source branch"
         uses: "actions/checkout@v4"
         with:
-          ref: "main"
+          ref: "{% raw %}${{ github.event.release.target_commitish }}{% endraw %}"
           fetch-depth: 0
 
       - name: "Setup environment"
@@ -128,17 +128,24 @@ jobs:
           poetry-version: "2.1.3"
           poetry-install-options: "--no-root"
 
-      - name: "Create release branch from main"
+      - name: "Create release branch and bump version"
         id: "branch"
         run: |
 
           git config user.name "{% raw %}${{ github.actor }}{% endraw %}"
           git config user.email "{% raw %}${{ github.actor }}{% endraw %}@users.noreply.github.com"
 
+          SOURCE_BRANCH="{% raw %}${{ github.event.release.target_commitish }}{% endraw %}"
+          if [ "$SOURCE_BRANCH" = "main" ]; then
+            TARGET_BRANCH="develop"
+          else
+            TARGET_BRANCH="$SOURCE_BRANCH"
+          fi
+
           TAG_NAME="{% raw %}${{ github.event.release.tag_name }}{% endraw %}"
           VERSION="${TAG_NAME#v}"
 
-          BRANCH_NAME="release-${VERSION}-to-develop"
+          BRANCH_NAME="release-${VERSION}-to-${TARGET_BRANCH}"
 
           # Ensure release branch doesn't already exist
           if git rev-parse --verify origin/$BRANCH_NAME > /dev/null 2>&1; then
@@ -148,18 +155,19 @@ jobs:
 
           git checkout -b "$BRANCH_NAME"
 
-          poetry version prepatch
+          poetry version prerelease
           git add pyproject.toml && git commit -m "Bump version"
           git push origin "$BRANCH_NAME"
 
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
 
-      - name: "Create Pull Request to develop"
+      - name: "Create Pull Request"
         env:
           GH_TOKEN: "{% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}"
         run: |
           gh pr create \
-            --title "Post release {% raw %}${{ github.event.release.tag_name }}{% endraw %} to develop" \
+            --title "Post release {% raw %}${{ github.event.release.tag_name }}{% endraw %} to {% raw %}${{ steps.branch.outputs.target_branch }}{% endraw %}" \
             --body "Please do a merge commit." \
-            --base "develop" \
+            --base "{% raw %}${{ steps.branch.outputs.target_branch }}{% endraw %}" \
             --head "{% raw %}${{ steps.branch.outputs.branch_name }}{% endraw %}"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
           GH_TOKEN: "{% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}"
         run: |
           gh pr create \
-            --title "Post release {% raw %}${{ github.event.release.tag_name }}{% endraw %} to {% raw %}${{ steps.branch.outputs.target_branch }}{% endraw %}" \
+            --title "Post release {% raw %}${{ github.event.release.tag_name }} to ${{ steps.branch.outputs.target_branch }}{% endraw %}" \
             --body "Please do a merge commit." \
             --base "{% raw %}${{ steps.branch.outputs.target_branch }}{% endraw %}" \
             --head "{% raw %}${{ steps.branch.outputs.branch_name }}{% endraw %}"


### PR DESCRIPTION
# Closes NAPPS-1164

## What's Changed

Updates the CI pipeline so that we auto increment post-release versions when creating a release from main, develop, next, and ltm-

## To Do

- [ ] Update the documentation.
- [x] Add changelog.
- [x] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
