### PR TITLE
Changed pylint master to main

### DIFF
--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -78,7 +78,7 @@ mkdocs-glightbox = "~0.5.2"
 all = [
 ]
 
-[tool.pylint.master]
+[tool.pylint.main]
 # Include the pylint_django plugin to avoid spurious warnings about Django patterns
 load-plugins="pylint_django, pylint_nautobot"
 ignore=".venv"

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -75,7 +75,7 @@ mkdocs-glightbox = "~0.5.2"
 all = [
 ]
 
-[tool.pylint.master]
+[tool.pylint.main]
 # Include the pylint_django plugin to avoid spurious warnings about Django patterns
 load-plugins = "pylint_django, pylint_nautobot"
 ignore = ".venv"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -74,7 +74,7 @@ mkdocs-glightbox = "~0.5.2"
 all = [
 ]
 
-[tool.pylint.master]
+[tool.pylint.main]
 # Include the pylint_django plugin to avoid spurious warnings about Django patterns
 load-plugins = "pylint_django, pylint_nautobot"
 ignore = ".venv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ mkdocstrings-python = "1.10.8"
 mkdocs-autorefs = "1.2.0"
 griffe = "1.1.1"
 
-[tool.pylint.master]
+[tool.pylint.main]
 ignore = ".venv"
 
 [tool.pylint.basic]


### PR DESCRIPTION
# Closes #[379](https://github.com/nautobot/cookiecutter-nautobot-app/issues/379)

## What's Changed

Summary: Request to update the Pylint configuration header in `pyproject.toml` across the repository and its templates.

**Technical Change:**

Rename: [tool.pylint.master] --> [tool.pylint.main]

Locations: Root `pyproject.toml` and template directories (app, chatops, ssot).

**Justification:**

Pylint has officially deprecated the [MASTER] terminology in favor of [MAIN]. While currently backwards compatible, transitioning now prevents future breaking changes and eliminates deprecation warnings for users of the cookiecutter template. This is a low-risk, syntax-only update to align with upstream Pylint documentation and industry naming standards.

NTC-5800

## To Do

- [ ] Update the documentation.
- [ ] Add changelog.
- [ ] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
