### PR TITLE
Fixed the prepare release workflow bumping the version on prereleases

### DIFF
--- a/changes/383.fixed
+++ b/changes/383.fixed
@@ -1,0 +1,1 @@
+Fixed the prepare release workflow bumping the version on prereleases resulting in a version number that is 2 ahead of the last release.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/prepare_release.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/prepare_release.yml
@@ -73,9 +73,25 @@ jobs:
 
       - name: "Determine New Version"
         id: "versioning"
+        env:
+          GH_TOKEN: "{% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}"
         run: |
-          # Perform the bump based on the user input
-          poetry version {% raw %}${{ github.event.inputs.bump_rule }}{% endraw %}
+          # Bump the poetry version based on the user input
+          CURRENT_POETRY_VER=$(poetry version --short)
+          set +e  # continue running if the next command fails
+          GITHUB_RELEASE_EXISTS=$(gh release view v$CURRENT_POETRY_VER --json publishedAt --jq '.publishedAt')
+          set -e
+          # Unconditionally bump the version if the current version is alpha0 or beta0
+          if [[ $CURRENT_POETRY_VER == *a0 || $CURRENT_POETRY_VER == *b0 || $CURRENT_POETRY_VER == *rc0 ]]; then
+            poetry version {% raw %}${{ github.event.inputs.bump_rule }}{% endraw %}
+          # If the bump rule is prerelease and a release doesn't already exist in github we don't bump the version
+
+          # This is because we've already bumped to the prerelease version after the previous release
+          elif [[ "{% raw %}${{ github.event.inputs.bump_rule }}{% endraw %}" == "prerelease" && "$CURRENT_POETRY_VER" =~ (a|b|rc)[0-9]+$ && -z "$GITHUB_RELEASE_EXISTS" ]]; then
+            echo "Prerelease v$CURRENT_POETRY_VER does not exist in github, using this version"
+          else
+            poetry version {% raw %}${{ github.event.inputs.bump_rule }}{% endraw %}
+          fi
 
           # Capture the New version string for use in other steps
           NEW_VER=$(poetry version --short)

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
 
           git checkout -b "$BRANCH_NAME"
 
-          poetry version prepatch
+          poetry version prerelease
           git add pyproject.toml && git commit -m "Bump version"
           git push origin "$BRANCH_NAME"
 

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/release_checklist.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/release_checklist.md
@@ -184,7 +184,7 @@ Publish the release!
 
 First, sync your `main` branch with upstream changes: `git switch main && git pull`.
 
-Create a new branch from `main` called `release-1.4.2-to-develop` and use `poetry version prepatch` to bump the development version to the next release.
+Create a new branch from `main` called `release-1.4.2-to-develop` and use `poetry version prerelease` to bump the development version to the next release.
 
 For example, if you just released `v1.4.2`:
 
@@ -192,8 +192,8 @@ For example, if you just released `v1.4.2`:
 > git switch -c release-1.4.2-to-develop main
 Switched to a new branch 'release-1.4.2-to-develop'
 
-> poetry version prepatch
-Bumping version from 1.4.2 to 1.4.3a1
+> poetry version prerelease
+Bumping version from 1.4.2 to 1.4.3a0
 
 > git add pyproject.toml && git commit -m "Bump version"
 


### PR DESCRIPTION
# Closes NAPPS-1159

## What's Changed

Fixed the prepare release workflow bumping the version on prereleases resulting in a version number that is 2 ahead of the last release.

Tested on dev example: https://github.com/nautobot/nautobot-app-dev-example/pull/160/

## To Do

- [ ] Update the documentation.
- [ ] Add changelog.
- [ ] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
