### PR TITLE
NAPPS-615 cookiecutter drop toml replacewith tomllib

### DIFF
--- a/changes/389.housekeeping
+++ b/changes/389.housekeeping
@@ -1,0 +1,1 @@
+Replaced the unmaintained `toml` dev dependency with stdlib `tomllib` (Python 3.11+) and `tomli` (Python 3.10 fallback).

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -48,7 +48,6 @@ pylint-django = ">=2.5.4"
 pylint-nautobot = ">=0.3.1"
 ruff = "0.5.5"
 yamllint = "*"
-toml = "*"
 # Python implementation of markdownlint
 pymarkdownlnt = "~0.9.30"
 Markdown = "*"

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -45,7 +45,6 @@ pylint-django = ">=2.5.4"
 pylint-nautobot = ">=0.3.1"
 ruff = "0.5.5"
 yamllint = "*"
-toml = "*"
 # Python implementation of markdownlint
 pymarkdownlnt = "~0.9.30"
 Markdown = "*"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/development/app_config_schema.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/development/app_config_schema.py
@@ -1,13 +1,18 @@
 """App Config Schema Generator and Validator."""
 
 import json
+import sys
 from importlib import import_module
 from os import getenv
 from pathlib import Path
 from urllib.parse import urlparse
 
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
 import jsonschema
-import toml
 from django.conf import settings
 from to_json_schema.to_json_schema import SchemaBuilder
 
@@ -25,7 +30,8 @@ def _enrich_object_schema(schema, defaults, required):
 
 
 def _main():
-    pyproject = toml.loads(Path("pyproject.toml").read_text())
+    with Path("pyproject.toml").open("rb") as f:
+        pyproject = tomllib.load(f)
     url = urlparse(pyproject["tool"]["poetry"]["repository"])
     _, owner, repository = url.path.split("/")
     package_name = pyproject["tool"]["poetry"]["packages"][0]["include"]

--- a/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -44,7 +44,6 @@ pylint-django = ">=2.5.4"
 pylint-nautobot = ">=0.3.1"
 ruff = "0.5.5"
 yamllint = "*"
-toml = "*"
 # Python implementation of markdownlint
 pymarkdownlnt = "~0.9.30"
 Markdown = "*"


### PR DESCRIPTION
# Closes NAPPS-615

## What's Changed
- Replaced outdated toml with tomllib/tomli

## To Do

- [ ] Update the documentation.
- [x] Add changelog.
- [ ] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
