### PR TITLE
Bump python in workflow

### DIFF
--- a/changes/390.housekeeping
+++ b/changes/390.housekeeping
@@ -1,0 +1,1 @@
+Bumped CI workflow matrix to test against Python 3.14.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -210,14 +210,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10"]  # 3.13 stable is tested in unittest_report stage.
+        python-version: ["3.10"]  # 3.14 stable is tested in unittest_report stage.
         db-backend: ["postgresql"]
         nautobot-version: ["stable"]
         include:
           - python-version: "3.10"
             db-backend: "postgresql"
             nautobot-version: "{{ min_nautobot_version }}"
-          - python-version: "3.13"
+          - python-version: "3.14"
             db-backend: "mysql"
             nautobot-version: "stable"
     runs-on: "ubuntu-latest"
@@ -264,7 +264,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
         db-backend: ["postgresql"]
         nautobot-version: ["stable"]
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
# NAPPS-1009

## What's Changed

- Bump python from 3.13 to 3.14 in CI Tests.
[Here](https://github.com/nautobot/nautobot-app-dev-example/pull/169) is the PR in dev example showing the change working.

## Screenshot of Dev example using Python 3.14 in unit tests
<img width="696" height="65" alt="Screenshot 2026-05-21 at 9 36 38 AM" src="https://github.com/user-attachments/assets/e28161a8-b461-4e3a-8f1e-ba0435293e87" />


## To Do

- [x] Add changelog.
