### PR TITLE
Closes #393: Add unittest coverage missing option

### DIFF
--- a/changes/393.added
+++ b/changes/393.added
@@ -1,0 +1,1 @@
+Added a `--missing` option to the `unittest-coverage` invoke target to show missing coverage lines.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -1008,10 +1008,16 @@ def unittest(  # noqa: PLR0913
     run_command(context, command)
 
 
-@task
-def unittest_coverage(context):
+@task(
+    help={
+        "missing": "Show line numbers of statements in each module that were not executed.",
+    },
+)
+def unittest_coverage(context, missing=False):
     """Report on code test coverage as measured by 'invoke unittest --coverage'."""
     command = "coverage report --skip-covered"
+    if missing:
+        command += " --show-missing"
 
     run_command(context, command)
 


### PR DESCRIPTION
# Closes #393 

## What's Changed

Added `--missing` argument to `unittest-coverage` invoke target to display the lines missing coverage.

## Sample Output

### Before
```
% invoke unittest-coverage
Running docker compose command "ps --services --filter status=running"
Running docker compose command "exec nautobot coverage report --skip-covered"
Name                             Stmts   Miss  Cover
----------------------------------------------------
nautobot_dev_example/models.py      18      2    89%
----------------------------------------------------
TOTAL                              121      2    98%
```

### After (no args)
Same as 'Before'

### After (with args)
```
% invoke unittest-coverage --missing
Running docker compose command "ps --services --filter status=running"
Running docker compose command "exec nautobot coverage report --skip-covered --show-missing"
Name                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------
nautobot_dev_example/models.py      18      2    89%   45-46
--------------------------------------------------------------
TOTAL                              121      2    98%

15 files skipped due to complete coverage.
```

## Discussion
The info supplied by coverage's `--show-missing` flag is available in both the lcov and xml reports, but those aren't nearly as at-a-glance easy to read. I opted for `--missing` rather than `--show-missing` because coverage's short flag for this option is `-m`, and I wanted the shortest thing to type to match the arg accepted by the underlying system. There /is/ a way to make both `--show-missing` and `-m` work:

```python
@task(
    help={
        "show-missing": "Show line numbers of statements in each module that were not executed.",
        "m": "Alias for --show-missing",
    },
    auto_shortflags=False,
)
def unittest_coverage(context, show_missing=False, m=False):
    """Report on code test coverage as measured by 'invoke unittest --coverage'."""
    command = "coverage report --skip-covered"
    if show_missing or m:
        command += " --show-missing"

    run_command(context, command)
```

...but that felt a little hacky to me. Happy to implement that if you'd prefer, just didn't seem the right option for a first swing.

## To Do

- [ ] Update the documentation.
- [x] Add changelog.
- [x] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
