### PR TITLE
Closes #395:  Backport pylint 'target' and 'recursive' from develop

### DIFF
--- a/changes/395.changed
+++ b/changes/395.changed
@@ -1,0 +1,1 @@
+Added `target` and `recursive` options to `invoke pylint` tasks.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -751,26 +751,49 @@ def hadolint(context):
     run_command(context, command)
 
 
-@task
-def pylint(context):
+@task(
+    help={
+        "target": "Module or file or directory to inspect, repeatable (default: app package)",
+        "recursive": "Must be set if target is a directory rather than a module or file name",
+    },
+    iterable=["target"],
+)
+def pylint(context, target=None, recursive=False):
     """Run pylint code analysis."""
     exit_code = 0
 
     base_pylint_command = 'pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml'
-    command = f"{base_pylint_command} {{ cookiecutter.app_name }}"
+    command = base_pylint_command
+    if recursive:
+        command += " --recursive=y"
+    command += f" {' '.join(target) if target else '{{ cookiecutter.app_name }}'}"
     if not run_command(context, command, warn=True):
         exit_code = 1
 
     # run the pylint_django migrations checkers on the migrations directory, if one exists
-    migrations_dir = Path(__file__).absolute().parent / Path("{{ cookiecutter.app_name }}") / Path("migrations")
+    app_dir = Path(__file__).absolute().parent / Path("{{ cookiecutter.app_name }}")
+    migrations_dir = app_dir / Path("migrations")
+    migrations_target_module = "{{ cookiecutter.app_name }}.migrations"
+    run_migrations_check = target is None
+    if target is not None:
+        for target_item in target:
+            target_item_normalized = Path(target_item).resolve()
+            if (
+                target_item_normalized in (app_dir, migrations_dir)
+                or target_item == migrations_target_module
+            ):
+                run_migrations_check = True
+                break
+
     if migrations_dir.is_dir():
-        migrations_pylint_command = (
-            f"{base_pylint_command} --load-plugins=pylint_django.checkers.migrations"
-            " --disable=all --enable=fatal,new-db-field-with-default,missing-backwards-migration-callable"
-            " {{ cookiecutter.app_name }}.migrations"
-        )
-        if not run_command(context, migrations_pylint_command, warn=True):
-            exit_code = 1
+        if run_migrations_check:
+            migrations_pylint_command = (
+                f"{base_pylint_command} --load-plugins=pylint_django.checkers.migrations"
+                " --disable=all --enable=fatal,new-db-field-with-default,missing-backwards-migration-callable"
+                " {{ cookiecutter.app_name }}.migrations"
+            )
+            if not run_command(context, migrations_pylint_command, warn=True):
+                exit_code = 1
     else:
         print("No migrations directory found, skipping migrations checks.")
 

--- a/tasks.py
+++ b/tasks.py
@@ -339,19 +339,10 @@ def generate_release_notes(context, version):
 # ------------------------------------------------------------------
 # TESTS
 # ------------------------------------------------------------------------------
-@task(
-    help={
-        "target": "Module or file or directory to inspect, repeatable (default: project python files and template tests)",
-        "recursive": "Must be set if target is a directory rather than a module or file name",
-    },
-    iterable=["target"],
-)
-def pylint(context, target=None, recursive=False):
+@task
+def pylint(context):
     """Run pylint code analysis."""
-    command = "pylint --rcfile pyproject.toml "
-    if recursive:
-        command += "--recursive=y "
-    command += " ".join(target) if target else collect_files(context)
+    command = f"pylint --rcfile pyproject.toml {collect_files(context)}"
     run_command(context, command)
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -339,10 +339,19 @@ def generate_release_notes(context, version):
 # ------------------------------------------------------------------
 # TESTS
 # ------------------------------------------------------------------------------
-@task
-def pylint(context):
+@task(
+    help={
+        "target": "Module or file or directory to inspect, repeatable (default: project python files and template tests)",
+        "recursive": "Must be set if target is a directory rather than a module or file name",
+    },
+    iterable=["target"],
+)
+def pylint(context, target=None, recursive=False):
     """Run pylint code analysis."""
-    command = f"pylint --rcfile pyproject.toml {collect_files(context)}"
+    command = "pylint --rcfile pyproject.toml "
+    if recursive:
+        command += "--recursive=y "
+    command += " ".join(target) if target else collect_files(context)
     run_command(context, command)
 
 


### PR DESCRIPTION
# Closes #395

## What's Changed

- Added repeatable `target` support to `invoke pylint`.
- Added a `recursive` option to `invoke pylint` for directory targets.

## Examples

### Help Output

```text
Usage: inv[oke] [--core-opts] pylint [--options] [other tasks here ...]

Docstring:
  Run pylint code analysis.

Options:
  -r, --recursive   Must be set if target is a directory rather than a module
                    or file name
  -t, --target      Module or file or directory to inspect, repeatable
                    (default: app package)
```

### Single Target Directory

```text
$ invoke pylint --target testing_app/tests --recursive

Running docker compose command "exec nautobot pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml --recursive=y testing_app/tests"
17:48:42.110 INFO    nautobot             __init__.py                              setup() : Nautobot 2.4.20 initialized!
Using config file pyproject.toml
Get ASTs.
AST for testing_app/tests/__init__.py
AST for testing_app/tests/test_forms.py
AST for testing_app/tests/test_views.py
AST for testing_app/tests/test_models.py
AST for testing_app/tests/test_api.py
AST for testing_app/tests/test_filters.py
AST for testing_app/tests/fixtures.py
Linting 7 modules.
```

Note: this command exited nonzero due to an existing `too-many-ancestors` finding in `testing_app/tests/test_filters.py`, but it confirmed the generated command includes `--recursive=y testing_app/tests`.

### Multiple File Targets

```text
$ invoke pylint --target testing_app/tests/__init__.py --target testing_app/api/__init__.py

Running docker compose command "exec nautobot pylint --verbose --init-hook "import nautobot; nautobot.setup()" --rcfile pyproject.toml testing_app/tests/__init__.py testing_app/api/__init__.py"
17:51:53.645 INFO    nautobot             __init__.py                              setup() : Nautobot 2.4.20 initialized!
Using config file pyproject.toml
Get ASTs.
AST for testing_app/tests/__init__.py
AST for testing_app/api/__init__.py
Linting 2 modules.
testing_app/tests/__init__.py (1 of 2)
testing_app/api/__init__.py (2 of 2)
```

## To Do

- [ ] Update the documentation.
- [x] Add changelog.
- [ ] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
