### PR TITLE
Closes #396: Backport ruff 'diff'

### DIFF
--- a/changes/396.changed
+++ b/changes/396.changed
@@ -1,0 +1,1 @@
+Added a `--diff` option to the `invoke ruff` tasks.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -790,11 +790,12 @@ def autoformat(context):
         "action": "Available values are `['lint', 'format']`. Can be used multiple times. (default: `--action lint --action format`)",
         "target": "File or directory to inspect, repeatable (default: all files in the project will be inspected)",
         "fix": "Automatically fix selected actions. May not be able to fix all issues found. (default: False)",
+        "diff": "Show diffs of changes. (default: False)",
         "output_format": "See https://docs.astral.sh/ruff/settings/#output-format for details. (default: `concise`)",
     },
     iterable=["action", "target"],
 )
-def ruff(context, action=None, target=None, fix=False, output_format="concise"):
+def ruff(context, action=None, target=None, fix=False, diff=False, output_format="concise"):  # noqa: PLR0913
     """Run ruff to perform code formatting and/or linting."""
     if not action:
         action = ["lint", "format"]
@@ -807,6 +808,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         command = "ruff format "
         if not fix:
             command += "--check "
+            if diff:
+                command += "--diff "
         command += " ".join(target)
         if not run_command(context, command, warn=True):
             exit_code = 1
@@ -815,6 +818,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         command = "ruff check "
         if fix:
             command += "--fix "
+        elif diff:
+            command += "--diff "
         command += f"--output-format {output_format} "
         command += " ".join(target)
         if not run_command(context, command, warn=True):

--- a/tasks.py
+++ b/tasks.py
@@ -357,12 +357,11 @@ def autoformat(context):
         "action": "Available values are `['lint', 'format']`. Can be used multiple times. (default: `['lint', 'format']`)",
         "target": "File or directory to inspect, repeatable (default: all files in the project will be inspected)",
         "fix": "Automatically fix selected actions. May not be able to fix all issues found. (default: False)",
-        "diff": "Show diffs of changes. (default: False)",
         "output_format": "See https://docs.astral.sh/ruff/settings/#output-format for details. (default: `concise`)",
     },
     iterable=["action", "target"],
 )
-def ruff(context, action=None, target=None, fix=False, diff=False, output_format="concise"):  # noqa: PLR0913
+def ruff(context, action=None, target=None, fix=False, output_format="concise"):
     """Run ruff to perform code formatting and/or linting."""
     if not action:
         action = ["lint", "format"]
@@ -375,8 +374,6 @@ def ruff(context, action=None, target=None, fix=False, diff=False, output_format
         command = "ruff format "
         if not fix:
             command += "--check "
-            if diff:
-                command += "--diff "
         command += " ".join(target)
         if not run_command(context, command, warn=True):
             exit_code = 1
@@ -385,8 +382,6 @@ def ruff(context, action=None, target=None, fix=False, diff=False, output_format
         command = "ruff check "
         if fix:
             command += "--fix "
-        elif diff:
-            command += "--diff "
         command += f"--output-format {output_format} "
         command += " ".join(target)
         if not run_command(context, command, warn=True):

--- a/tasks.py
+++ b/tasks.py
@@ -357,11 +357,12 @@ def autoformat(context):
         "action": "Available values are `['lint', 'format']`. Can be used multiple times. (default: `['lint', 'format']`)",
         "target": "File or directory to inspect, repeatable (default: all files in the project will be inspected)",
         "fix": "Automatically fix selected actions. May not be able to fix all issues found. (default: False)",
+        "diff": "Show diffs of changes. (default: False)",
         "output_format": "See https://docs.astral.sh/ruff/settings/#output-format for details. (default: `concise`)",
     },
     iterable=["action", "target"],
 )
-def ruff(context, action=None, target=None, fix=False, output_format="concise"):
+def ruff(context, action=None, target=None, fix=False, diff=False, output_format="concise"):  # noqa: PLR0913
     """Run ruff to perform code formatting and/or linting."""
     if not action:
         action = ["lint", "format"]
@@ -374,6 +375,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         command = "ruff format "
         if not fix:
             command += "--check "
+            if diff:
+                command += "--diff "
         command += " ".join(target)
         if not run_command(context, command, warn=True):
             exit_code = 1
@@ -382,6 +385,8 @@ def ruff(context, action=None, target=None, fix=False, output_format="concise"):
         command = "ruff check "
         if fix:
             command += "--fix "
+        elif diff:
+            command += "--diff "
         command += f"--output-format {output_format} "
         command += " ".join(target)
         if not run_command(context, command, warn=True):


### PR DESCRIPTION
# Closes #396

## What's Changed

- Added a `diff` option to `invoke ruff`.
- Updated `invoke ruff --action format --diff` to run `ruff format --check --diff`.
- Updated `invoke ruff --action lint --diff` to run `ruff check --diff`.

## Examples

### Help Output

```text
Usage: inv[oke] [--core-opts] ruff [--options] [other tasks here ...]

Docstring:
  Run ruff to perform code formatting and/or linting.

Options:
  -a, --action                        Available values are `['lint',
                                      'format']`. Can be used multiple times.
                                      (default: `--action lint --action
                                      format`)
  -d, --diff                          Show diffs of changes. (default: False)
  -f, --fix                           Automatically fix selected actions. May
                                      not be able to fix all issues found.
                                      (default: False)
  -o STRING, --output-format=STRING   See https://docs.astral.sh/ruff/settings/
                                      #output-format for details. (default:
                                      `concise`)
  -t, --target                        File or directory to inspect, repeatable
                                      (default: all files in the project will
                                      be inspected)
```

### Format Diff

```text
$ invoke ruff --action format --diff --target tasks.py

Running docker compose command "exec nautobot ruff format --check --diff tasks.py"
--- tasks.py
+++ tasks.py
@@ -205,21 +205,16 @@
 def _ensure_creds_env_file(context):
     """Ensure that the development/creds.env file exists."""
-    if not os.path.exists(
-        os.path.join(context.testing_app.compose_dir, "creds.env")
-    ):
+    if not os.path.exists(os.path.join(context.testing_app.compose_dir, "creds.env")):
...
1 file would be reformatted
```

Note: this command exited nonzero because `ruff format --check --diff` found formatting changes, which is expected behavior.

### Lint Diff

```text
$ invoke ruff --action lint --diff --target tasks.py

Running docker compose command "exec nautobot ruff check --diff --output-format concise tasks.py"
```

This command exited successfully.

## To Do

- [ ] Update the documentation.
- [x] Add changelog.
- [ ] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
