### PR TITLE
[Backport] Added CI job to verify branch names for PRs to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,19 @@ on: # yamllint disable-line rule:truthy rule:comments
   pull_request: ~
 
 jobs:
+  branch-protection:
+    if: "github.event_name == 'pull_request'"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Check branch protection rules"
+        run: |
+          echo "Source branch: $GITHUB_HEAD_REF"
+          echo "Target branch: $GITHUB_BASE_REF"
+          if [[ "$GITHUB_BASE_REF" == "main" && ! "$GITHUB_HEAD_REF" =~ ^release ]]; then
+            echo "❌ Error: Pull requests into 'main' are only allowed from branches starting with 'release'"
+            exit 1
+          fi
+          echo "✅ Branch protection check passed"
   changelog:
     if: >
       contains(fromJson('["develop","ltm-1.6","ltm-2.4"]'), github.base_ref) &&

--- a/changes/329.added
+++ b/changes/329.added
@@ -1,0 +1,1 @@
+Added a CI job to check that pull requests into `main` are only allowed from branches starting with `release`.


### PR DESCRIPTION
This is a copy/paste backport of #330 for the LTM branch. Since we added it as a required CI in the github settings, it fails to pass for all LTM PRs because it is missing.