### PR TITLE
Fix djlint CI failure on apps with no Django templates

### DIFF
--- a/changes/402.housekeeping
+++ b/changes/402.housekeeping
@@ -1,0 +1,1 @@
+Fixed djlint CI failure for apps with no Django templates, caused by djlint 1.39.5 returning a non-zero exit code when no files match the lint run.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/tasks.py
@@ -895,9 +895,17 @@ def djlint(context, target=None):
     command = "djlint --lint "
     command += " ".join(target)
 
-    exit_code = 0 if run_command(context, command, warn=True) else 1
-    if exit_code != 0:
-        raise Exit(code=exit_code)
+    # As of djlint 1.39.5, djlint returns a non-zero exit code when no files match the lint run
+    # (https://github.com/djlint/djLint/issues/1112)
+    result = run_command(context, command, warn=True, hide="both", pty=False)
+    print(result.stdout, end="")
+
+    if result.ok:
+        return
+    if "No files to check" in result.stdout:
+        return
+    print(result.stderr, end="")
+    raise Exit(code=result.return_code or 1)
 
 
 @task(


### PR DESCRIPTION
## What's Changed

Added a check to skip running djlint when there are no *.html files in app's templates directory. This handles the non-zero exit code returned when there are no files to check, introduced in djlint's 1.39.5 version. This reflects the change made in https://github.com/nautobot/nautobot-app-dev-example/pull/176

## To Do

- [ ] Update the documentation.
- [x] Add changelog.
- [x] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
