### PR TITLE
Make Python and Poetry versions env vars

### DIFF
--- a/changes/403.housekeeping
+++ b/changes/403.housekeeping
@@ -1,0 +1,1 @@
+Changed the release workflow to define the Python and Poetry versions as workflow-level environment variables.

--- a/nautobot-app-commercial/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
+++ b/nautobot-app-commercial/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:  # yamllint disable-line rule:truthy rule:comments
   release:
     types: ["published"]
 
+env:
+  POETRY_VERSION: "2.1.3"
+  PYTHON_VERSION: "3.12"
+
 jobs:
   build:
     name: "Build package with poetry"
@@ -14,8 +18,8 @@ jobs:
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
-          poetry-version: "2.1.3"
-          python-version: "3.12"
+          poetry-version: "{% raw %}${{ env.POETRY_VERSION }}{% endraw %}"
+          python-version: "{% raw %}${{ env.PYTHON_VERSION }}{% endraw %}"
           poetry-install-options: "--no-root"
       - name: "Build Documentation"
         run: "poetry run invoke build-and-check-docs"
@@ -62,7 +66,7 @@ jobs:
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
-          poetry-version: "2.1.3"
+          poetry-version: "{% raw %}${{ env.POETRY_VERSION }}{% endraw %}"
           poetry-install-options: "--dry-run"
 
       - name: "Retrieve built package from cache"
@@ -132,7 +136,7 @@ jobs:
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
-          poetry-version: "2.1.3"
+          poetry-version: "{% raw %}${{ env.POETRY_VERSION }}{% endraw %}"
           poetry-install-options: "--no-root"
 
       - name: "Create release branch and bump version"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on: # yamllint disable-line rule:truthy rule:comments
   release:
     types: ["published"]
 
+env:
+  POETRY_VERSION: "2.1.3"
+  PYTHON_VERSION: "3.12"
+
 jobs:
   build:
     name: "Build package with poetry"
@@ -14,8 +18,8 @@ jobs:
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
-          poetry-version: "2.1.3"
-          python-version: "3.12"
+          poetry-version: "{% raw %}${{ env.POETRY_VERSION }}{% endraw %}"
+          python-version: "{% raw %}${{ env.PYTHON_VERSION }}{% endraw %}"
           poetry-install-options: "--no-root"
       - name: "Build Documentation"
         run: "poetry run invoke build-and-check-docs"
@@ -125,7 +129,7 @@ jobs:
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:
-          poetry-version: "2.1.3"
+          poetry-version: "{% raw %}${{ env.POETRY_VERSION }}{% endraw %}"
           poetry-install-options: "--no-root"
 
       - name: "Create release branch and bump version"


### PR DESCRIPTION
## What's Changed

Changed the release workflow to define the Python and Poetry versions as workflow-level environment variables, which reflects the change introduced in https://github.com/nautobot/nautobot-app-dev-example/pull/175/.

Also, I noticed I could do the same thing in `ci.yml` and `prepare_release.yml` - should I left these files alone or right now is a moment as good as any to do it?

## To Do

- [ ] Update the documentation.
- [x] Add changelog.
- [x] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
