### PR TITLE
Add release job to open PR from main into next

### DIFF
--- a/changes/404.housekeeping
+++ b/changes/404.housekeeping
@@ -1,0 +1,1 @@
+Added a release workflow job that opens a pull request from `main` into `next` after a release is published from `main`.

--- a/nautobot-app-commercial/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
+++ b/nautobot-app-commercial/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
@@ -243,3 +243,57 @@ jobs:
             --body "Please do a merge commit." \
             --base "develop" \
             --head "{% raw %}${{ steps.branch.outputs.branch_name }}{% endraw %}"
+
+  create-pr-to-next:
+    if: "github.event.release.target_commitish == 'main'"
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Create a PR from main into next"
+    needs:
+      - "publish-github"
+      - "publish-artifactory"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout main"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "main"
+          fetch-depth: 0
+
+      - name: "Create release branch from main"
+        id: "branch"
+        run: |
+          # Skip if there is no 'next' branch to merge into.
+          if ! git ls-remote --exit-code --heads origin next > /dev/null 2>&1; then
+            echo "No 'next' branch exists; skipping main -> next PR."
+            exit 0
+          fi
+
+          TAG_NAME="{% raw %}${{ github.event.release.tag_name }}{% endraw %}"
+          VERSION="${TAG_NAME#v}"
+
+          BRANCH_NAME="release-${VERSION}-to-next"
+
+          # Ensure release branch doesn't already exist
+          if git rev-parse --verify origin/$BRANCH_NAME > /dev/null 2>&1; then
+            echo "Error: Release branch $BRANCH_NAME already exists."
+            exit 1
+          fi
+
+          # Base off main, since it's in the released state.
+          git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME"
+
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: "Create a PR to next"
+        if: "steps.branch.outputs.branch_name != ''"
+        env:
+          GH_TOKEN: "{% raw %}${{ secrets.NTC_LLC_NAUTOBOT_APPS_REPO_WORKFLOW_GH_TOKEN }}{% endraw %}"
+        run: |
+          gh pr create \
+            --title "Post release {% raw %}${{ github.event.release.tag_name }}{% endraw %} to next" \
+            --body "Please do a merge commit." \
+            --base "next" \
+            --head "{% raw %}${{ steps.branch.outputs.branch_name }}{% endraw %}"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
@@ -238,3 +238,57 @@ jobs:
             --body "Please do a merge commit." \
             --base "develop" \
             --head "{% raw %}${{ steps.branch.outputs.branch_name }}{% endraw %}"
+
+  create-pr-to-next:
+    if: "github.event.release.target_commitish == 'main'"
+    permissions:
+      contents: "write"
+      pull-requests: "write"
+    name: "Create a PR from main into next"
+    needs:
+      - "publish-github"
+      - "publish-pypi"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout main"
+        uses: "actions/checkout@v4"
+        with:
+          ref: "main"
+          fetch-depth: 0
+
+      - name: "Create release branch from main"
+        id: "branch"
+        run: |
+          # Skip if there is no 'next' branch to merge into.
+          if ! git ls-remote --exit-code --heads origin next > /dev/null 2>&1; then
+            echo "No 'next' branch exists; skipping main -> next PR."
+            exit 0
+          fi
+
+          TAG_NAME="{% raw %}${{ github.event.release.tag_name }}{% endraw %}"
+          VERSION="${TAG_NAME#v}"
+
+          BRANCH_NAME="release-${VERSION}-to-next"
+
+          # Ensure release branch doesn't already exist
+          if git rev-parse --verify origin/$BRANCH_NAME > /dev/null 2>&1; then
+            echo "Error: Release branch $BRANCH_NAME already exists."
+            exit 1
+          fi
+
+          # Base off main, since it's in the released state.
+          git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME"
+
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: "Create a PR to next"
+        if: "steps.branch.outputs.branch_name != ''"
+        env:
+          GH_TOKEN: "{% raw %}${{ secrets.GH_NAUTOBOT_BOT_TOKEN }}{% endraw %}"
+        run: |
+          gh pr create \
+            --title "Post release {% raw %}${{ github.event.release.tag_name }}{% endraw %} to next" \
+            --body "Please do a merge commit." \
+            --base "next" \
+            --head "{% raw %}${{ steps.branch.outputs.branch_name }}{% endraw %}"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/release_checklist.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/release_checklist.md
@@ -70,6 +70,12 @@ A draft release will automatically be created in GitHub when the Prepare Release
 
 After a release has been published from the `main` branch, a new PR will automatically be created to merge the changes from `main` back into `develop` with a version bump to the next development version (e.g. `1.4.3a1`). Review and merge this PR once CI has completed and the PR has been approved.
 
+### Sync the Release to `next`
+
+Publishing a release from the `main` branch will also automatically create a PR to forward-port the released changes from `main` into `next`, so the `next` branch stays up to date.
+
+If no `next` branch exists, this step is skipped automatically.
+
 ## Legacy Documentation for Releases
 
 Please use the above process for all releases going forward, but if you need to refer to the old manual release process for any reason, here are the steps that were previously followed for releases.


### PR DESCRIPTION
# Closes NAPPS-1249

## What's Changed

Adds automation so that publishing a release from `main` automatically opens a PR forward-porting `main` into `next`.

Based on previous post-release `main` -> `develop` sync, but for the `main` -> `next` direction.

This reflects the changes introduces in https://github.com/nautobot/nautobot-app-dev-example/pull/172

## To Do

- [x] Update the documentation.
- [x] Add changelog.
- [x] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
