### PR TITLE
Fix .claude global gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,9 +307,9 @@ development/*.txt
 # Invoke overrides
 invoke.yml
 
-# Claude Code
-CLAUDE.md
-.claude/
+# Claude Code local settings
+.claude/settings.local.json
+CLAUDE.local.md
 
 # OpenAI Codex CLI
 AGENTS.md

--- a/changes/405.fixed
+++ b/changes/405.fixed
@@ -1,0 +1,1 @@
+Changed `.gitignore` to allow committing shared Claude Code configuration, ignoring only per-user local files.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.gitignore
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.gitignore
@@ -310,9 +310,9 @@ public
 /dump.sql
 /{{ cookiecutter.app_name }}/static/{{ cookiecutter.app_name }}/docs
 
-# Claude Code
-CLAUDE.md
-.claude/
+# Claude Code local settings
+.claude/settings.local.json
+CLAUDE.local.md
 
 # OpenAI Codex CLI
 AGENTS.md


### PR DESCRIPTION
# Closes N/A

## What's Changed

- Removed `CLAUDE.md` and `.claude/` from the ignore list
- Added `.claude/settings.local.json` and `CLAUDE.local.md`

Claude Code distinguishes between team-shared and personal configuration:

- **Shared (should be committed):** `CLAUDE.md` (project instructions), `.claude/settings.json` (permissions, hooks, additional directories), and `.claude/commands/`, `agents/`, `skills/`, `rules/`. Checking these in gives every developer on a project the same instructions and permission baseline, which is a prerequisite for standardizing Claude Code behavior across our repos.
- **Personal (should stay ignored):** `.claude/settings.local.json` (per-user overrides; also where "Yes, don't ask again" approvals accumulate) and `CLAUDE.local.md` (per-user instructions).

## To Do

- [ ] Update the documentation.
- [ ] Add changelog.
- [ ] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
