### PR TITLE
NAPPS-1493 | Bump minimum Nautobot version to 3.2.0 for the commercial cookie

### DIFF
--- a/changes/407.changed
+++ b/changes/407.changed
@@ -1,0 +1,1 @@
+Changed the minimum supported Nautobot version to 3.2.0 for apps baked from the `nautobot-app-commercial` cookie, updating both the baked `pyproject.toml` constraint and the CI test matrix.

--- a/nautobot-app-commercial/cookiecutter.json
+++ b/nautobot-app-commercial/cookiecutter.json
@@ -18,6 +18,6 @@
     "_extensions": [
         "local_extensions.camel_case_to_kebab",
         "local_extensions.camel_case_to_words",
-        "local_extensions.NautobotVersions"
+        "local_extensions.CommercialNautobotVersions"
     ]
 }

--- a/nautobot-app/local_extensions.py
+++ b/nautobot-app/local_extensions.py
@@ -1,9 +1,11 @@
 """Local extensions for Nautobot Cookies."""
+
 import re
 
+from cookiecutter.utils import simple_filter
 from jinja2 import Environment
 from jinja2.ext import Extension
-from cookiecutter.utils import simple_filter
+
 
 @simple_filter
 def camel_case_to_kebab(name: str) -> str:
@@ -15,6 +17,7 @@ def camel_case_to_kebab(name: str) -> str:
     words = re.findall(r"[A-Z]?[a-z]+|[A-Z]{2,}(?=[A-Z][a-z]|\d|\W|$)|\d+|[A-Z]{2,}|[A-Z]$", name)
     return "-".join(words).lower()
 
+
 @simple_filter
 def camel_case_to_words(name: str) -> str:
     """Converts a camel case name to words.
@@ -25,6 +28,7 @@ def camel_case_to_words(name: str) -> str:
     words = re.findall(r"[A-Z]?[a-z]+|[A-Z]{2,}(?=[A-Z][a-z]|\d|\W|$)|\d+|[A-Z]{2,}|[A-Z]$", name)
     return " ".join(words)
 
+
 class NautobotVersions(Extension):  # pylint: disable=abstract-method
     """Jinja2 extension to set a minimum/maximum Nautobot version."""
 
@@ -33,3 +37,12 @@ class NautobotVersions(Extension):  # pylint: disable=abstract-method
 
         environment.globals.update(min_nautobot_version="3.1.0")
         environment.globals.update(upper_bound_nautobot_version="4.0.0")
+
+
+class CommercialNautobotVersions(NautobotVersions):
+    """Jinja2 extension to set a minimum/maximum Nautobot version for commercial apps."""
+
+    def __init__(self, environment: Environment):
+        super().__init__(environment)
+
+        environment.globals.update(min_nautobot_version="3.2.0")

--- a/nautobot-app/local_extensions.py
+++ b/nautobot-app/local_extensions.py
@@ -39,7 +39,7 @@ class NautobotVersions(Extension):  # pylint: disable=abstract-method
         environment.globals.update(upper_bound_nautobot_version="4.0.0")
 
 
-class CommercialNautobotVersions(NautobotVersions):
+class CommercialNautobotVersions(NautobotVersions):  # pylint: disable=abstract-method
     """Jinja2 extension to set a minimum/maximum Nautobot version for commercial apps."""
 
     def __init__(self, environment: Environment):


### PR DESCRIPTION
# Closes NAPPS-1493

## What's Changed

- Bumped the minimum supported Nautobot version to 3.2.0 for apps baked from the `nautobot-app-commercial` cookie; the baked `pyproject.toml` constraint and CI test matrix both pick up the new version.
- Added a `CommercialNautobotVersions` Jinja extension in the shared `local_extensions.py` and pointed `nautobot-app-commercial/cookiecutter.json` at it, keeping the shared file symlinked (same shared-file approach as #406) while the open-source cookies stay at 3.1.0.

## To Do

- [x] Update the documentation. (No documentation changes needed.)
- [x] Add changelog.
- [ ] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.