### PR TITLE
Fixed `changes/.gitignore` being lost

### DIFF
--- a/changes/412.fixed
+++ b/changes/412.fixed
@@ -1,0 +1,1 @@
+Fixed `changes/.gitignore` being lost when baking the commercial, SSoT, and ChatOps templates, which left generated apps with a `changes` directory that disappeared on first commit.

--- a/nautobot-app-chatops/tests/test_bake_nautobot_app_chatops.py
+++ b/nautobot-app-chatops/tests/test_bake_nautobot_app_chatops.py
@@ -1,5 +1,6 @@
 # pylint: disable=duplicate-code
 """Cookie tests"""
+
 from os import environ
 
 
@@ -16,6 +17,11 @@ def test_bake_project(cookies):
     assert "pyproject.toml" in found_toplevel_files
     assert "README.md" in found_toplevel_files
     assert "LICENSE" in found_toplevel_files
+
+    # `changes/.gitignore` is what keeps the empty towncrier fragment directory in git. It is a
+    # symlink into `nautobot-app`; if `changes` itself is ever made a directory symlink again,
+    # cookiecutter will not descend into it and this file will silently vanish from the bake.
+    assert (result.project_path / "changes" / ".gitignore").is_file()
 
 
 def test_bake_nautobot_execution(cookies_baked_nautobot_app_chatops):

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/changes
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/changes
@@ -1,1 +1,0 @@
-../../nautobot-app/{{ cookiecutter.project_slug }}/changes

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/changes/.gitignore
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/changes/.gitignore
@@ -1,0 +1,1 @@
+../../../nautobot-app/{{ cookiecutter.project_slug }}/changes/.gitignore

--- a/nautobot-app-commercial/tests/test_bake_nautobot_app_commercial.py
+++ b/nautobot-app-commercial/tests/test_bake_nautobot_app_commercial.py
@@ -18,6 +18,11 @@ def test_bake_project(cookies):
     assert "README.md" in found_toplevel_files
     assert "COPYRIGHT" in found_toplevel_files
 
+    # `changes/.gitignore` is what keeps the empty towncrier fragment directory in git. It is a
+    # symlink into `nautobot-app`; if `changes` itself is ever made a directory symlink again,
+    # cookiecutter will not descend into it and this file will silently vanish from the bake.
+    assert (result.project_path / "changes" / ".gitignore").is_file()
+
 
 def test_bake_nautobot_execution(cookies_baked_nautobot_app_commercial):
     """

--- a/nautobot-app-commercial/{{ cookiecutter.project_slug }}/changes
+++ b/nautobot-app-commercial/{{ cookiecutter.project_slug }}/changes
@@ -1,1 +1,0 @@
-../../nautobot-app/{{ cookiecutter.project_slug }}/changes

--- a/nautobot-app-commercial/{{ cookiecutter.project_slug }}/changes/.gitignore
+++ b/nautobot-app-commercial/{{ cookiecutter.project_slug }}/changes/.gitignore
@@ -1,0 +1,1 @@
+../../../nautobot-app/{{ cookiecutter.project_slug }}/changes/.gitignore

--- a/nautobot-app-ssot/tests/test_bake_nautobot_app_ssot.py
+++ b/nautobot-app-ssot/tests/test_bake_nautobot_app_ssot.py
@@ -1,5 +1,6 @@
 # pylint: disable=duplicate-code
 """Cookie tests"""
+
 from os import environ
 
 
@@ -16,6 +17,11 @@ def test_bake_project(cookies):
     assert "pyproject.toml" in found_toplevel_files
     assert "README.md" in found_toplevel_files
     assert "LICENSE" in found_toplevel_files
+
+    # `changes/.gitignore` is what keeps the empty towncrier fragment directory in git. It is a
+    # symlink into `nautobot-app`; if `changes` itself is ever made a directory symlink again,
+    # cookiecutter will not descend into it and this file will silently vanish from the bake.
+    assert (result.project_path / "changes" / ".gitignore").is_file()
 
 
 def test_bake_nautobot_execution(cookies_baked_nautobot_app_ssot):

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/changes
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/changes
@@ -1,1 +1,0 @@
-../../nautobot-app/{{ cookiecutter.project_slug }}/changes

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/changes/.gitignore
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/changes/.gitignore
@@ -1,0 +1,1 @@
+../../../nautobot-app/{{ cookiecutter.project_slug }}/changes/.gitignore

--- a/nautobot-app/tests/test_bake_nautobot_app.py
+++ b/nautobot-app/tests/test_bake_nautobot_app.py
@@ -1,5 +1,6 @@
 # pylint: disable=duplicate-code
 """Cookie tests"""
+
 from os import environ
 
 
@@ -16,6 +17,9 @@ def test_bake_project(cookies):
     assert "pyproject.toml" in found_toplevel_files
     assert "README.md" in found_toplevel_files
     assert "LICENSE" in found_toplevel_files
+
+    # `changes/.gitignore` is what keeps the empty towncrier fragment directory in git.
+    assert (result.project_path / "changes" / ".gitignore").is_file()
 
 
 def test_bake_nautobot_execution(cookies_baked_nautobot_app):


### PR DESCRIPTION
# Closes N/A

## What's Changed

The recent change to nautobot-app-commercial in the commercial apps showed that `changes/.gitignore` was being deleted by drift manager. This fixes that by changing the symlink to point to `changes/.gitignore` instead of `changes/`

## To Do

- [ ] Update the documentation.
- [ ] Add changelog.
- [ ] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
