### PR TITLE
Update 3rd party actions pins to bring our actions up to date and relive the node20 deprecation notices.

### DIFF
--- a/.github/workflows/bake-templates.yml
+++ b/.github/workflows/bake-templates.yml
@@ -28,7 +28,7 @@ jobs:
             invoke_local_env: "INVOKE_NAUTOBOT_MY_COMMERCIAL_APP_LOCAL"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Setup Poetry"
         uses: "networktocode/gh-action-setup-poetry-environment@v6"
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           fetch-depth: "0"
       - name: "Setup environment"
@@ -48,7 +48,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:

--- a/changes/415.changed
+++ b/changes/415.changed
@@ -1,0 +1,3 @@
+Changed GHA `action/checkout@v4` to `action/checkout@v7` which is the latest.
+Changed Docker owned GHA action `"docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0` to `"docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e"  # v4.3.0`
+Changed Docker owned GHA action `"docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25"  # v5.4.0` to `"docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a"  # v7.3.0`

--- a/nautobot-app-commercial/{{ cookiecutter.project_slug }}/.github/workflows/prepare_release.yml
+++ b/nautobot-app-commercial/{{ cookiecutter.project_slug }}/.github/workflows/prepare_release.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           # If target_branch is 'main', use 'develop' as the source branch. Otherwise, the source and target branch are the same.
           ref: "{% raw %}${{ github.event.inputs['target_branch'] == 'main' && 'develop' || github.event.inputs['target_branch'] }}{% endraw %}"

--- a/nautobot-app-commercial/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
+++ b/nautobot-app-commercial/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v7"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
@@ -54,7 +54,7 @@ jobs:
       contents: "write"
     needs: "build"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v7"
       - name: "Retrieve built package from cache"
         uses: "actions/download-artifact@v4"
         with:
@@ -72,7 +72,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/v')"
     needs: "build"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v7"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
@@ -141,7 +141,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout source branch"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           ref: "{% raw %}${{ github.event.release.target_commitish }}{% endraw %}"
           fetch-depth: 0
@@ -211,7 +211,7 @@ jobs:
       - "publish-artifactory"
     steps:
       - name: "Checkout develop"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           ref: "develop"
           fetch-depth: 0
@@ -272,7 +272,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout main"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           ref: "main"
           fetch-depth: 0

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
@@ -45,7 +45,7 @@ jobs:
       INVOKE_{{ cookiecutter.app_name.upper() }}_LOCAL: "True"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
@@ -68,7 +68,7 @@ jobs:
       INVOKE_{{ cookiecutter.app_name.upper() }}_LOCAL: "True"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
@@ -91,7 +91,7 @@ jobs:
       INVOKE_{{cookiecutter.app_name.upper()}}_LOCAL: "True"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
@@ -109,7 +109,7 @@ jobs:
       INVOKE_{{ cookiecutter.app_name.upper() }}_LOCAL: "True"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
@@ -128,7 +128,7 @@ jobs:
       INVOKE_{{ cookiecutter.app_name.upper() }}_LOCAL: "True"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
@@ -151,7 +151,7 @@ jobs:
       INVOKE_{{ cookiecutter.app_name.upper() }}_LOCAL: "True"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
@@ -174,7 +174,7 @@ jobs:
       INVOKE_{{ cookiecutter.app_name.upper() }}_LOCAL: "True"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Download poetry.lock artifact"
         uses: "actions/download-artifact@v4"
         with:
@@ -208,7 +208,7 @@ jobs:
       INVOKE_{{ cookiecutter.app_name.upper() }}_NAUTOBOT_VER: "{% raw %}${{ matrix.nautobot-version }}{% endraw %}"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
@@ -228,9 +228,9 @@ jobs:
         run: "poetry run invoke lock --constrain-nautobot-ver --constrain-python-ver={% raw %}${{ matrix.python-version }}{% endraw %}"
       - name: "Set up Docker Buildx"
         id: "buildx"
-        uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0
+        uses: "docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e"  # v4.3.0
       - name: "Build"
-        uses: "docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25"  # v5.4.0
+        uses: "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a"  # v7.3.0
         with:
           builder: "{% raw %}${{ steps.buildx.outputs.name }}{% endraw %}"
           context: "./"
@@ -277,7 +277,7 @@ jobs:
       INVOKE_{{ cookiecutter.app_name.upper() }}_NAUTOBOT_VER: "{% raw %}${{ matrix.nautobot-version }}{% endraw %}"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
@@ -297,9 +297,9 @@ jobs:
         run: "poetry run invoke lock --constrain-nautobot-ver --constrain-python-ver={% raw %}${{ matrix.python-version }}{% endraw %}"
       - name: "Set up Docker Buildx"
         id: "buildx"
-        uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0
+        uses: "docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e"  # v4.3.0
       - name: "Build"
-        uses: "docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25"  # v5.4.0
+        uses: "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a"  # v7.3.0
         with:
           builder: "{% raw %}${{ steps.buildx.outputs.name }}{% endraw %}"
           context: "./"
@@ -341,7 +341,7 @@ jobs:
       INVOKE_{{ cookiecutter.app_name.upper() }}_NAUTOBOT_VER: "{% raw %}${{ matrix.nautobot-version }}{% endraw %}"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
@@ -361,9 +361,9 @@ jobs:
         run: "poetry run invoke lock --constrain-nautobot-ver --constrain-python-ver={% raw %}${{ matrix.python-version }}{% endraw %}"
       - name: "Set up Docker Buildx"
         id: "buildx"
-        uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0
+        uses: "docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e"  # v4.3.0
       - name: "Build"
-        uses: "docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25"  # v5.4.0
+        uses: "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a"  # v7.3.0
         with:
           builder: "{% raw %}${{ steps.buildx.outputs.name }}{% endraw %}"
           context: "./"
@@ -417,7 +417,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out repository code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           fetch-depth: "0"
       - name: "Download poetry.lock artifact"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/prepare_release.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/prepare_release.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           # If target_branch is 'main', use 'develop' as the source branch. Otherwise, the source and target branch are the same.
           ref: "{% raw %}${{ github.event.inputs['target_branch'] == 'main' && 'develop' || github.event.inputs['target_branch'] }}{% endraw %}"

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     if: "startsWith(github.ref, 'refs/tags/v')"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v7"
       - name: "Setup environment"
         uses: "networktocode/gh-action-setup-poetry-environment@v7"
         with:
@@ -44,7 +44,7 @@ jobs:
       contents: "write"
     needs: "build"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v7"
       - name: "Retrieve built package from cache"
         uses: "actions/download-artifact@v4"
         with:
@@ -121,7 +121,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout source branch"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           ref: "{% raw %}${{ github.event.release.target_commitish }}{% endraw %}"
           fetch-depth: 0
@@ -190,7 +190,7 @@ jobs:
       - "publish-pypi"
     steps:
       - name: "Checkout develop"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           ref: "develop"
           fetch-depth: 0
@@ -251,7 +251,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout main"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@v7"
         with:
           ref: "main"
           fetch-depth: 0


### PR DESCRIPTION
# Closes #<ISSUE_NUMBER>

## What's Changed

- Changed GHA `action/checkout@v4` to `action/checkout@v7` which is the latest.
- Changed Docker owned GHA action `"docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0` to `"docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e"  # v4.3.0`
- Changed Docker owned GHA action `"docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25"  # v5.4.0` to `"docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a"  # v7.3.0`

## To Do

- [ ] Update the documentation.
- [ ] Add changelog.
- [ ] Verify your changes by testing them in the [dev-example](https://github.com/nautobot/nautobot-app-dev-example) repository before merging.
