### PR TITLE
Add AI context and contribution standards to the open source templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -312,18 +312,19 @@ invoke.yml
 CLAUDE.local.md
 
 # OpenAI Codex CLI
-AGENTS.md
-AGENTS.override.md
+# Anchored to the repository root so the templates can ship their own agent files.
+/AGENTS.md
+/AGENTS.override.md
 .codex/
 
 # Google Gemini CLI
-GEMINI.md
+/GEMINI.md
 .gemini/
 .vertexai/
 
 # Cursor (Anysphere)
 .cursor/
-.cursorrules
+/.cursorrules
 .cursorignore
 .cursorindexingignore
 

--- a/changes/275.added
+++ b/changes/275.added
@@ -1,0 +1,2 @@
+Added `AGENTS.md` agent instruction files to the `nautobot-app`, `nautobot-app-chatops`, and `nautobot-app-ssot` templates, with `CLAUDE.md`, `GEMINI.md`, `.cursorrules`, and `.github/copilot-instructions.md` pointing to them.
+Added a root `CONTRIBUTING.md` with an AI-usage policy to the open source templates, and an AI-assistance disclosure item to the pull request template.

--- a/nautobot-app-chatops/tests/test_bake_nautobot_app_chatops.py
+++ b/nautobot-app-chatops/tests/test_bake_nautobot_app_chatops.py
@@ -16,6 +16,12 @@ def test_bake_project(cookies):
     assert "pyproject.toml" in found_toplevel_files
     assert "README.md" in found_toplevel_files
     assert "LICENSE" in found_toplevel_files
+    assert "CONTRIBUTING.md" in found_toplevel_files
+    assert "AGENTS.md" in found_toplevel_files
+    assert "CLAUDE.md" in found_toplevel_files
+    assert "GEMINI.md" in found_toplevel_files
+    assert ".cursorrules" in found_toplevel_files
+    assert (result.project_path / ".github" / "copilot-instructions.md").is_file()
 
 
 def test_bake_nautobot_execution(cookies_baked_nautobot_app_chatops):

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/.cursorrules
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/.cursorrules
@@ -1,0 +1,1 @@
+../../nautobot-app/{{ cookiecutter.project_slug }}/.cursorrules

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/.github/copilot-instructions.md
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../../../nautobot-app/{{ cookiecutter.project_slug }}/.github/copilot-instructions.md

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/AGENTS.md
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/AGENTS.md
@@ -1,0 +1,825 @@
+# Agent Instructions --- Nautobot ChatOps App
+
+You are an AI coding agent working inside a **Nautobot ChatOps App** repository. Your mission is
+to generate **small, readable, test-backed** changes. Follow **Nautobot
+patterns**, the **ChatOps patterns** for interactive chat commands, and
+this repository's tooling and style.
+
+> **Canonical file:** `AGENTS.md` is the single source of truth for AI agents in
+> this repository. `CLAUDE.md`, `GEMINI.md`, `.cursorrules` and
+> `.github/copilot-instructions.md` all point here. Update this file, not the
+> pointers.
+> **Scope:** You may add path-scoped GitHub Copilot rules via
+> `.github/instructions/*.instructions.md` if truly necessary.
+
+---
+
+## 0) Quick Facts (for Agents)
+
+- **Stack:** Django app that runs inside **Nautobot** (network SoT &
+  automation). Uses Postgres, Redis, and Celery via Nautobot. Prefer idiomatic
+  **Django** and **Nautobot helper APIs**.
+- **ChatOps:** This app extends Nautobot ChatOps functionality with **worker
+  functions**, **subcommands**, and **dispatcher patterns** for chat platform
+  integration (Slack, Microsoft Teams, Webex, Mattermost).
+- **Python:** `>=3.10,<3.15`, as declared in `pyproject.toml`.
+- **Dependency & venv:** **Poetry** only.
+- **Task runner:** `invoke` (always via Poetry).
+- **Style:** Ruff + Pylint; **imports at the top**; prefer **docstrings over
+  inline comments**; clear, explicit code.
+
+---
+
+## 1) Tooling & Environment (Poetry-first)
+
+Always use Poetry for dependency management and virtualenvs.
+
+- Install deps:  
+  `poetry install`
+- **Run tasks (required):**  
+  `poetry run invoke <task> [args]`
+
+Examples:
+- `poetry run invoke autoformat`
+- `poetry run invoke ruff`
+- `poetry run invoke pylint`
+- `poetry run invoke tests`
+- `poetry run invoke check-migrations`
+- `poetry run invoke makemigrations -n <name>`
+- `poetry run invoke markdownlint`
+- `poetry run invoke yamllint`
+
+Prefer `invoke` tasks over ad-hoc commands. **When suggesting commands, prefix them
+with `poetry run`.**
+
+---
+
+## 2) Style, Lint, and Documentation
+
+- **Ruff** is used for formatting and linting; **Pylint** for static analysis.
+  Generated code must pass both.
+- **Imports:**  
+    - Place **all imports at the top** of the file (after the module docstring).  
+    - No wildcard imports; prefer absolute imports and explicit symbols.  
+    - Aliasing Nautobot app modules is fine for clarity, e.g.:  
+      `from nautobot.ipam import models as ipam_models`
+    - Prefer imports from `nautobot.apps` instead of `nautobot.core`
+- **Docstrings > inline comments:**  
+    - Keep inline comments to the minimum for non-obvious logic.  
+    - Put purpose/params/returns/side-effects in **module/class/function
+      docstrings**.  
+- Write straightforward, readable code over clever one-liners.
+- **Docs:**
+    - If you add/change features, update `docs/` accordingly.
+    - Use `mkdocs` syntax.
+    - Run `poetry run invoke markdownlint` to validate and resolve any issues with
+      the markdown syntax.
+    - Run `poetry run invoke yamllint` to validate YAML files (e.g., mkdocs.yml).
+    - Run `poetry run invoke build-and-check-docs` to validate.
+
+---
+
+## 3) Use Nautobot's Frameworks (default choices)
+
+When scaffolding features, use Nautobot's base classes and helpers first:
+
+- **Models:** `PrimaryModel` (full Nautobot features) or `BaseModel` as
+  appropriate.
+- **Forms:** `NautobotModelForm` (+ `NautobotBulkEditForm` for bulk edits, `NautobotFilterForm` for filter forms).
+- **FilterSets:** `NautobotModelFilterSet` (`Meta.fields = "__all__"` unless
+  strongly justified).
+- **Serializers:** `NautobotModelSerializer` (writeable) / `BaseModelSerializer`
+  (simple read-only).
+- **API views:** `NautobotModelViewSet`.
+- **UI views:** `NautobotUIViewSet` (unifies list/detail/edit/delete).
+- **URLs/Routes:** Use helpers such as `get_route_for_model()`; do **not**
+  hand-craft route strings.
+
+**Why:** These reduce boilerplate, align with core Nautobot behavior, and improve
+maintainability.
+
+---
+
+## 4) Models & Data Layer
+
+- Prefer natural keys (e.g., unique `name`) or PKs; add `slug` only with clear
+  rationale.
+- Use constant `CHARFIELD_MAX_LENGTH` for text lengths unless you have a very good
+  reason not to.
+- Avoid `null=True` on strings; use empty string `""` when semantically empty.
+- For `ManyToManyField`, declare an explicit **through** model. We follow the
+  convention of using both model names and the word Assignment for **through**
+  models. Ex. `AccessPointDeviceAssignment`
+- If searchable, populate `searchable_models` on the `NautobotAppConfig` in the
+  `__init__.py` file.
+
+---
+
+## 5) Forms, Filters, Templates, and UI Patterns
+
+- **Forms:**  
+    - Use `DynamicModelChoiceField` for large foreign keys.  
+    - Put complex validation in `clean()` (model or form as appropriate).
+- **Filters:**  
+    - Use `RelatedMembershipBooleanFilter` for boolean relationship filters
+      (`has_*`).  
+    - Use `NaturalKeyOrPKMultipleChoiceFilter` for FK filters where applicable.
+    - Use `SearchFilter` for `q` parameter search logic.
+- **Templates (rare — prefer UI Component Framework):**
+    - **Prefer the UI Component Framework** for detail views unless strongly justified.
+    - When templates are necessary, extend Nautobot base templates; prefer provided filters
+      (`|hyperlinked_object`, `|placeholder`, etc.) over `mark_safe`/hand-rolled anchors.
+- **UI Patterns:**  
+    - Prefer **tabs** (via `NautobotUIViewSet`) for distinct data categories.  
+    - Use full-width detail layouts for dense content.  
+    - Provide **stats tiles** / instance counts if helpful.  
+    - For long-running actions, use **AJAX modal + polling** (Jobs/Celery).  
+    - Use inline edit sparingly and always re-validate server-side.
+
+---
+
+## 6) Migrations
+
+- **Do not generate migrations automatically.** Migration generation should be done by a developer, not by AI.
+- If models change, remind the developer to:
+    - `poetry run invoke check-migrations`
+    - `poetry run invoke makemigrations -n <meaningful_name>`
+- Keep schema and data migrations separate and reversible.
+- Use descriptive migration names (e.g., `devicenote_initial`, `provider_increase_account_length`).
+- Ruff-format generated migrations for consistency.
+
+---
+
+## 7) Tests --- What to Generate (Nautobot-style, **required**)
+
+**Use Nautobot's testing base classes and mixins. Don't use `unittest.TestCase`
+or raw `django.test.TestCase`.**
+
+### 7.1 Test Types & Base Classes
+
+- **Unit tests:** inherit from `nautobot.apps.testing.TestCase` (auto-tagged `unit`).
+- **View tests:** use `nautobot.apps.testing.ViewTestCases` mixins.
+- **API tests:** use `nautobot.apps.testing.APIViewTestCases` mixins
+  (`CreateObjectViewTestCase`, `ListObjectsViewTestCase`, `GetObjectViewTestCase`,
+  `UpdateObjectViewTestCase`, `DeleteObjectViewTestCase`, and bulk variants).
+  These enforce `?brief=` behavior (declare `brief_fields`) and exercise bulk
+  endpoints.
+- **Filter tests:** use `nautobot.apps.testing.FilterTestCases` (generic
+  boolean/multi-choice/tags tests).
+- **Form tests:** use `nautobot.core.testing.FormTestCases.BaseFormTestCase`.
+- **Integration (browser) tests:** `nautobot.apps.testing.SeleniumTestCase`
+  (auto-tagged `integration`).
+- **Migration tests:** `django_test_migrations.MigratorTestCase` (auto-tagged
+  `migration_test`).
+- **When to use `TransactionTestCase`:** Default to `TestCase` for all standard tests (models, views, filters, API) — it is faster because it uses transaction rollback. Use `TransactionTestCase` only when testing **Nautobot Jobs** end-to-end via `run_job_for_testing()`, because Jobs run through Celery and need real committed transactions visible across process boundaries. Note that `setUpTestData()` does **not** work with `TransactionTestCase`; create test data in `setUp()` or in individual test methods instead.
+
+### 7.2 Testing Mixin Strategy (`nautobot.apps.testing`)
+
+Nautobot provides **namespace classes** (`ViewTestCases`, `APIViewTestCases`, `FilterTestCases`) containing **inner test-case classes** that app developers compose via multiple inheritance. This pattern eliminates boilerplate by providing 30+ test methods (CRUD, permissions, bulk operations, pagination, query performance) from a single declarative class.
+
+**How it works:** Inherit from a composite class (e.g., `ViewTestCases.PrimaryObjectViewTestCase`) and provide declarative data (`model`, `form_data`, `csv_data`, `bulk_edit_data`) in `setUpTestData`. The framework generates and runs all relevant test methods automatically.
+
+**Works well with:**
+- Standard CRUD operations using `NautobotUIViewSet` / `NautobotModelViewSet`
+- Consistent permission testing (403/302 without, 200 with)
+- API contract testing (serializer validation, depth params, bulk ops)
+- Filter testing via `generic_filter_tests` declarations
+- Performance regression testing (`assertApproximateNumQueries`)
+
+**Does not cover:**
+- Highly custom views (wizards, multi-step forms, non-CRUD actions)
+- Custom DRF `@action` endpoints beyond standard CRUD
+- Non-model-backed views (dashboards, reports)
+- Complex form logic with conditional fields or JavaScript-dependent validation
+
+### 7.3 Directory Layout
+
+```python
+<app>/tests/
+  test_models.py
+  test_filters.py
+  test_api.py
+  test_views.py
+  integration/
+    test_*.py
+  migration/
+    test_*.py
+```
+
+### 7.4 Running Tests
+
+- All tests (fast fixtures enabled):
+
+**Help**
+
+```bash
+poetry run invoke tests
+```
+
+```text
+Usage: inv[oke] [--core-opts] tests [--options] [other tasks here ...]
+
+Docstring:
+  Run all tests for this app.
+
+Options:
+  -f, --failfast    fail as soon as a single test fails don't run the entire test
+                    suite. (default: False)
+  -k, --keepdb      Save and re-use test database between test runs for faster
+                    re-testing. (default: False)
+  -l, --lint-only   Only run linters; unit tests will be excluded. (default: False)
+```
+
+### 7.5 Test Data & Fixtures
+
+- Prefer creating objects via model `.create()`/`.save()` inside tests.
+- Avoid calling factories in `setUp()` / `setUpTestData()`; factory output can be
+  stateful.
+- Rely on cached/seeded fixtures where provided by the runner to keep tests fast
+  and deterministic.
+
+### 7.6 API Test Skeleton (what the agent should scaffold)
+
+```python
+"""API tests for Widget."""
+from nautobot.apps.testing import APIViewTestCases
+from . import models
+
+class WidgetAPITests(
+    APIViewTestCases.CreateObjectViewTestCase,
+    APIViewTestCases.ListObjectsViewTestCase,
+    APIViewTestCases.GetObjectViewTestCase,
+    APIViewTestCases.UpdateObjectViewTestCase,
+    APIViewTestCases.DeleteObjectViewTestCase,
+):
+    """CRUD tests for the Widget REST API."""
+    model = models.Widget
+
+    # Returned keys for `?brief=true` (sorted)
+    brief_fields = ["display", "id", "name", "url"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.create_data = [
+            {"name": "Widget A"},
+            {"name": "Widget B"},
+        ]
+        cls.update_data = {"name": "Widget A+"}
+```
+
+### 7.7 Filter Test Skeleton
+
+```python
+"""Filter tests for Widget."""
+from nautobot.apps.testing import FilterTestCases
+from . import filters as widget_filters, models
+
+class WidgetFilterTests(FilterTestCases.FilterTestCase):
+    """Generic filter assertions for WidgetFilterSet."""
+    filterset = widget_filters.WidgetFilterSet
+    queryset = models.Widget.objects.all()
+
+    # Optional: map filter names to queryset kwargs to exercise generic cases.
+    generic_filter_tests = [
+        ["name", "name"],
+        # ["owner_id", "owner__id"],
+    ]
+```
+
+### 7.8 Views Test Skeleton
+
+```python
+"""View tests for Widget UI."""
+from nautobot.apps.testing import ViewTestCases
+from . import models
+
+class WidgetUIViewTests(ViewTestCases.PrimaryObjectViewTestCase):
+    """UI list/detail/create/edit/delete tests for Widget."""
+    model = models.Widget
+    bulk_edit_data = {"name": "Bulk Renamed"}
+```
+
+### 7.9 OpenAPI Schema Checks
+
+Nautobot's built-in test infrastructure includes OpenAPI schema validation. Ensure your app's serializers and endpoints remain schema-valid by running the full test suite (`poetry run invoke tests`). Do not generate custom OpenAPI schema tests — the framework handles this automatically.
+
+### 7.10 Unittest Task (Django/Nautobot runner)
+
+In addition to `invoke tests` (the default Nautobot test runner), this repo can
+use **Django's unittest-style runner** via the `unittest` Invoke task when
+present. Prefer this when you want stock unittest selection semantics or when a
+plugin/app intends to mirror Nautobot core's runner behavior.
+
+**Help**  
+```bash
+poetry run invoke unittest -h
+```
+
+```text
+Usage: inv[oke] [--core-opts] unittest [--options] [other tasks here ...]
+
+Docstring:
+  Run Nautobot unit tests.
+
+Options:
+  -b, --[no-]buffer             Discard output from passing tests
+  -c, --coverage                Enable coverage reporting. Defaults to False
+  -f, --failfast                Fail fast on first failure
+  -k, --keepdb                  Re-use the test database between runs
+  -l STRING, --label=STRING     Directory or module label to test (runs subset)
+  -p STRING, --pattern=STRING   Select specific test methods/classes/modules
+  -s, --skip-docs-build         Skip building docs before tests
+  -v, --verbose                 Verbose test output
+```
+
+**When to use which**
+
+- Use `poetry run invoke tests` for the full testing suite experience (ruff,
+  yamllint, markdownlint, check_migrations, pylint, build_and_check_docs,
+  validate_app_config, unittest, unitttest_coverage, coverage_lcov).
+- Use `poetry run invoke unittest` for Django/unittest-native selection
+  (labels/patterns), quick targeted runs, or parity with Nautobot core's CI
+  jobs.
+
+**Common recipes**  
+- Run with coverage:  
+  `poetry run invoke unittest --coverage`
+- Target a specific module (label):  
+  `poetry run invoke unittest --label myapp.tests.test_api`
+- Match by pattern (method/class):  
+  `poetry run invoke unittest --pattern "WidgetAPITests and test_list_objects"`
+- Re-use the DB between runs for speed:  
+  `poetry run invoke unittest --keepdb`
+- Fail fast & suppress noise from passing tests:  
+  `poetry run invoke unittest --failfast --buffer`
+- Skip docs build if unchanged:  
+  `poetry run invoke unittest --skip-docs-build`
+
+> **Note:** Always prefix with `poetry run` to ensure tests execute inside the
+project's Poetry environment.
+
+---
+
+## 8) ChatOps-Specific Patterns & Architecture
+
+### 8.1 Worker Functions Structure
+
+ChatOps apps follow a **three-layer architecture**: input (views/sockets) → worker
+→ output (dispatchers).
+
+**Worker module organization:**
+- Main worker function in `worker.py` using `handle_subcommands()`
+- Subcommands using `@subcommand_of()` decorator
+- Each subcommand function takes `dispatcher` as first argument
+
+**Main worker skeleton:**
+```python
+"""Worker functions implementing Nautobot "mycommand" command and subcommands."""
+
+from nautobot_chatops.workers import subcommand_of, handle_subcommands
+
+def mycommand(subcommand, **kwargs):
+    """Interact with mycommand app."""
+    return handle_subcommands("mycommand", subcommand, **kwargs)
+
+@subcommand_of("mycommand")
+def get_device_info(dispatcher, device_name):
+    """Get device information from Nautobot."""
+    # Worker logic here
+    return True  # or False, or (status, details)
+```
+
+### 8.2 Subcommand Patterns
+
+**Function naming:** Use underscores; they convert to hyphens in chat
+(`get_device_info` → `get-device-info`)
+
+**Required signature:** `def subcommand_func(dispatcher, arg1, arg2=None, ...):`
+
+**Return values:**
+- `return False` - Command incomplete (prompting user), don't log
+- `return True` - Command succeeded
+- `return CommandStatusChoices.STATUS_SUCCEEDED` - Command succeeded
+  (explicit)
+- `return (CommandStatusChoices.STATUS_FAILED, "Error details")` - Command
+  failed with details
+
+**Multi-word arguments:** Support quoted arguments by preserving quotes in prompts:
+```python
+action = f"get-sites location '{city}'"  # Preserve quotes for multi-word params
+dispatcher.prompt_for_text(action_id=action, help_text="Enter number", label="Limit")
+```
+
+### 8.3 Dispatcher Interface Patterns
+
+**Platform-agnostic output:** Workers call dispatcher methods; never
+platform-specific APIs directly.
+
+**Common dispatcher methods:**
+- `dispatcher.send_markdown(text)` - Simple markdown message
+- `dispatcher.send_blocks(blocks)` - Rich formatted blocks
+- `dispatcher.send_large_table(headers, *rows)` - Table data
+- `dispatcher.prompt_from_menu(action, text, choices)` - Interactive menu
+- `dispatcher.prompt_for_text(action_id, help_text, label)` - Text input prompt
+- `dispatcher.command_response_header(command, subcommand)` - Standard header blocks
+
+**Block formatting example:**
+```python
+dispatcher.send_blocks([
+    *dispatcher.command_response_header("mycommand", "get-device"),
+    dispatcher.markdown_block(f"Device: **{device.name}**"),
+    dispatcher.markdown_block(f"Status: {device.status}"),
+])
+```
+
+### 8.4 Parameter Validation & User Prompting
+
+**Progressive prompting:** If required parameters missing, prompt user and return
+`False`:
+```python
+@subcommand_of("mycommand")
+def get_device_info(dispatcher, site_name=None, device_name=None):
+    """Get device information."""
+    if not site_name:
+        sites = [
+            (site.name, site.slug) for site in Location.objects.filter(location_type__name="Site")
+        ]
+        dispatcher.prompt_from_menu("mycommand get-device-info", "Select site", sites)
+        return False
+  
+    if not device_name:
+        devices = Device.objects.filter(location__slug=site_name)
+        choices = [(dev.name, dev.name) for dev in devices]
+        dispatcher.prompt_from_menu(
+            f"mycommand get-device-info {site_name}", "Select device", choices
+        )
+        return False
+  
+    # Process the command
+    device = Device.objects.get(name=device_name)
+    dispatcher.send_markdown(f"Device **{device.name}** status: {device.status}")
+    return True
+```
+
+### 8.5 Platform Considerations & Output Formatting
+
+**Text limits:** Different platforms have different limits:
+- Slack: ~4000 characters for messages, ~3000 for blocks
+- Microsoft Teams: ~69 character line wrapping, no preformatted text in cards
+
+**Responsive design:**
+- Use `send_large_table()` for data that might exceed platform limits
+- Use `send_blocks()` for rich formatting when possible
+- Fall back to `send_markdown()` for simple text
+
+**Table handling:**
+```python
+# For large datasets that may exceed platform limits
+dispatcher.send_large_table(
+    ["Device", "Site", "Status", "IP Address"],
+    *[(dev.name, dev.location.name, dev.status, dev.primary_ip) for dev in devices]
+)
+```
+
+### 8.6 Error Handling & Status Reporting
+
+**Graceful error handling:**
+```python
+@subcommand_of("mycommand")
+def risky_operation(dispatcher, device_name):
+    """Perform operation that might fail."""
+    try:
+        device = Device.objects.get(name=device_name)
+        # Perform operation
+        dispatcher.send_markdown(f"✅ Operation completed for {device.name}")
+        return True
+    except Device.DoesNotExist:
+        dispatcher.send_markdown(f"❌ Device '{device_name}' not found")
+        return (CommandStatusChoices.STATUS_FAILED, f"Device {device_name} not found")
+    except Exception as exc:
+        dispatcher.send_markdown(f"❌ Operation failed: {exc}")
+        return (CommandStatusChoices.STATUS_FAILED, str(exc))
+```
+
+### 8.7 Testing ChatOps Commands
+
+**Test structure for workers:**
+```python
+"""Tests for mycommand ChatOps workers."""
+from unittest.mock import Mock, patch
+from nautobot.apps.testing import TestCase
+from nautobot_chatops.tests.helpers import ChatOpsTestCase
+from . import worker
+
+class MyCommandWorkerTest(ChatOpsTestCase):
+    """Test mycommand worker functions."""
+  
+    def test_get_device_info_success(self):
+        """Test successful device info retrieval."""
+        mock_dispatcher = Mock()
+        device = self.device_factory()
+  
+        result = worker.get_device_info(mock_dispatcher, device.name)
+  
+        self.assertTrue(result)
+        mock_dispatcher.send_markdown.assert_called_once()
+  
+    def test_get_device_info_missing_params(self):
+        """Test prompting when parameters missing."""
+        mock_dispatcher = Mock()
+  
+        result = worker.get_device_info(mock_dispatcher)
+  
+        self.assertFalse(result)
+        mock_dispatcher.prompt_from_menu.assert_called_once()
+```
+
+---
+
+## 9) Celery & Jobs
+
+- For long-running work or external calls, prefer **Celery tasks** or **Nautobot
+  Jobs**.
+- Do **not** block web requests with heavy processing.
+- **ChatOps workers run in Celery:** All ChatOps commands execute as Celery
+  tasks, so they can handle longer operations without blocking the chat platform
+  response.
+
+---
+
+## 10) Security & Secrets
+
+- Never hard-code secrets/tokens/credentials.  
+- Use Nautobot Secrets / External Integrations.  
+- Scrub PII and sensitive network details from examples/tests.
+- **ChatOps security:** Commands inherit Nautobot user permissions; ensure
+  proper user account linking between chat platforms and Nautobot accounts.
+
+---
+
+## 11) Performance & DB
+
+- Prefer queryset filters/bulk ops over per-row loops.  
+- Use `select_related` / `prefetch_related` where appropriate.  
+- Add indexes for frequently filtered fields; justify in migration message.
+
+---
+
+## 12) Git & Branching
+
+- Small, focused branches.  
+- PRs must include tests, migration notes (if any), and "how to test" steps.  
+- Reference related issues.  
+- Target the `develop` branch for PRs (not `main`, which is reserved for releases).
+
+---
+
+## 13) PR Hygiene --- What the Agent Should Suggest
+
+- Clear, action-oriented title and description.  
+- Link to issue(s) and include screenshots/GIFs for UI work.  
+- Call out any migrations and potential data impacts.  
+- Keep the diff small and logically cohesive.
+- Add a changelog fragment at `changes/<issue>.<type>`. Valid types are `added`,
+  `changed`, `deprecated`, `fixed`, `removed`, and `security`. Write one complete
+  sentence in past tense, starting with a capital letter and ending with a period.
+- Tick the AI-assistance disclosure item in the pull request template, and name the
+  provider and model you used.
+
+### Maintainer Expectations for AI Contributions
+
+Maintainers accept AI-assisted contributions under these conditions.
+
+- A human author owns the change. That author understands every line and answers
+  review questions without further generation.
+- The author runs `poetry run invoke tests` locally, and the suite passes, before
+  the pull request opens.
+- The author discloses AI assistance in the pull request, with the provider and the
+  model. See `CONTRIBUTING.md`.
+- New behavior arrives with tests. A bug fix arrives with the regression test that
+  would have caught it.
+- Maintainers close large, unreviewed, machine-generated pull requests without a
+  detailed review.
+
+---
+
+## 14) Snippets the Agent Should Prefer
+
+**ChatOps Worker Function**
+```python
+"""Worker functions implementing Nautobot "mycommand" command and subcommands."""
+from nautobot_chatops.workers import subcommand_of, handle_subcommands
+from nautobot.dcim.models import Device
+
+def mycommand(subcommand, **kwargs):
+    """Interact with mycommand app."""
+    return handle_subcommands("mycommand", subcommand, **kwargs)
+
+@subcommand_of("mycommand")
+def get_device_status(dispatcher, device_name=None):
+    """Get the status of a device."""
+    if not device_name:
+        devices = Device.objects.all()[:20]  # Limit choices
+        choices = [(dev.name, dev.name) for dev in devices]
+        dispatcher.prompt_from_menu(
+            "mycommand get-device-status", "Select device", choices
+        )
+        return False
+  
+    try:
+        device = Device.objects.get(name=device_name)
+        dispatcher.send_blocks([
+            *dispatcher.command_response_header("mycommand", "get-device-status"),
+            dispatcher.markdown_block(f"**Device:** {device.name}"),
+            dispatcher.markdown_block(f"**Status:** {device.status}"),
+            dispatcher.markdown_block(f"**Location:** {device.location}"),
+        ])
+        return True
+    except Device.DoesNotExist:
+        dispatcher.send_markdown(f"❌ Device '{device_name}' not found")
+        return False
+```
+
+**ChatOps Worker Test**
+```python
+"""Tests for mycommand ChatOps workers."""
+from unittest.mock import Mock
+from nautobot.apps.testing import TestCase
+from nautobot.dcim.models import Device
+from . import worker
+
+class MyCommandWorkerTest(TestCase):
+    """Test mycommand worker functions."""
+  
+    def test_get_device_status_success(self):
+        """Test successful device status retrieval."""
+        mock_dispatcher = Mock()
+        device = Device.objects.create(
+            name="test-device", device_type=self.device_type, location=self.location
+        )
+  
+        result = worker.get_device_status(mock_dispatcher, device.name)
+  
+        self.assertTrue(result)
+        mock_dispatcher.send_blocks.assert_called_once()
+  
+    def test_get_device_status_prompts_when_no_device(self):
+        """Test prompting when no device specified."""
+        mock_dispatcher = Mock()
+  
+        result = worker.get_device_status(mock_dispatcher)
+  
+        self.assertFalse(result)
+        mock_dispatcher.prompt_from_menu.assert_called_once()
+```
+
+**Model**
+```python
+"""DeviceNote model."""
+from django.db import models
+from nautobot.apps.constants import CHARFIELD_MAX_LENGTH
+from nautobot.apps.models import PrimaryModel
+
+class DeviceNote(PrimaryModel):
+    """Freeform note attached to a device."""
+    name = models.CharField(max_length=CHARFIELD_MAX_LENGTH, unique=True)
+    content = models.TextField(blank=True, default="")
+    tenant = models.ForeignKey(
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="device_notes",
+        blank=True,
+        null=True,
+    )
+  
+    class Meta:
+        ordering = ("name",)
+
+    def __str__(self):
+        """Stringify instance."""
+        return self.name
+```
+
+**Serializer**
+```python
+"""Serializer for DeviceNote."""
+from nautobot.apps.api import NautobotModelSerializer, TaggedModelSerializerMixin
+from .models import DeviceNote
+
+class DeviceNoteSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
+    """Serialize DeviceNote objects."""
+    class Meta:
+        model = DeviceNote
+        fields = "__all__"
+```
+
+**FilterSet**
+```python
+"""FilterSet for DeviceNote."""
+from nautobot.apps.filters import NautobotFilterSet, TenancyModelFilterSetMixin
+from .models import DeviceNote
+
+class DeviceNoteFilter(TenancyModelFilterSetMixin, NautobotFilterSet):
+    """Filter DeviceNote by name/content."""
+    class Meta:
+        model = DeviceNote
+        fields = "__all__"
+```
+
+**API ViewSet**
+```python
+"""API viewset for DeviceNote."""
+from nautobot.apps.api import NautobotModelViewSet
+from .filters import DeviceNoteFilter
+from .serializers import DeviceNoteSerializer
+from .models import DeviceNote
+
+class DeviceNoteViewSet(NautobotModelViewSet):
+    """List, retrieve, and manage DeviceNotes via REST API."""
+    queryset = DeviceNote.objects.all()
+    serializer_class = DeviceNoteSerializer
+    filterset_class = DeviceNoteFilter
+```
+
+**UI ViewSet**
+```python
+"""UI viewset for DeviceNote."""
+from nautobot.apps.views import NautobotUIViewSet
+from .models import DeviceNote
+from .tables import DeviceNoteTable
+from .forms import DeviceNoteForm
+
+class DeviceNoteUIViewSet(NautobotUIViewSet):
+    """UI for listing, viewing, creating, and editing DeviceNotes."""
+    queryset = DeviceNote.objects.all()
+    table = DeviceNoteTable
+    bulk_update_form_class = DeviceNoteForm
+    form_class = DeviceNoteForm
+```
+
+**Migrations (command)**
+```bash
+poetry run invoke makemigrations -n devicenote_initial
+```
+
+---
+
+## 15) Optional: Folder-Specific Instructions
+
+If needed, add `.github/instructions/*.instructions.md` with path-scoped
+front-matter to apply specialized guidance to certain subtrees (e.g., `docs/`,
+`nautobot_plugin_tooling/`). Keep rules minimal to avoid confusion.
+
+---
+
+## 16) Final Checklist (for every change)
+
+- [ ] Commands are shown as `poetry run invoke ...`  
+- [ ] Imports are at the top; docstrings explain intent/usage  
+- [ ] Nautobot base classes, viewsets, and helpers are used  
+- [ ] **ChatOps workers use `@subcommand_of()` decorator and proper dispatcher
+      interface**
+- [ ] **ChatOps functions return appropriate status (True/False/status tuple)**
+- [ ] **ChatOps commands handle missing parameters with progressive prompting**
+- [ ] Tests cover models/filters/API/views **and ChatOps workers** with Nautobot
+      base classes & mixins  
+- [ ] Migrations are checked/generated, named meaningfully, and reversible  
+- [ ] Querysets are optimized; indexes added if needed  
+- [ ] No secrets/PII in code, tests, or docs  
+- [ ] Ruff & Pylint clean
+- [ ] PR description includes "how to test" and references related issues
+
+---
+
+## 17) Authoritative Nautobot Repositories & Examples
+
+When proposing or generating **Nautobot-specific code**, prefer patterns proven in
+the official repositories below.
+Use them for import paths, base-class usage, testing mixins, viewset patterns,
+job/celery conventions, and UI Component Framework examples.
+
+- **Nautobot Core:** https://github.com/nautobot/nautobot/
+- **Nautobot App --- ChatOps:**
+  https://github.com/nautobot/nautobot-app-chatops
+- **Nautobot App --- SSoT:** https://github.com/nautobot/nautobot-app-ssot
+- **Nautobot App --- Nornir:** https://github.com/nautobot/nautobot-app-nornir
+- **Nautobot App --- Golden Config:** https://github.com/nautobot/nautobot-app-golden-config
+- **Nautobot App --- DNS Models:** https://github.com/nautobot/nautobot-app-dns-models
+- **Nautobot App --- Firewall Models:** https://github.com/nautobot/nautobot-app-firewall-models
+- **Nautobot App --- BGP Models:**
+  https://github.com/nautobot/nautobot-app-bgp-models
+
+**Guidance for agents**
+- Prefer examples from these repos over generic Django code.
+- Mirror **base class** usage (`PrimaryModel`, `NautobotModelViewSet`,
+  `NautobotUIViewSet`, etc.).
+- Follow **testing** patterns under `nautobot/apps/testing` (mixins and tags)
+  rather than ad-hoc tests.
+- **For ChatOps patterns:** Study `nautobot-app-chatops` workers, dispatchers,
+  and command structure.
+- Reuse **filter/serializer** patterns and import paths exactly as shown in the
+  official code.
+- Avoid Nautobot 1.x and 2.x-only patterns; target **Nautobot 3.x** APIs and UI Component
+  Framework.
+- If proposing URLs, prefer helper utilities (e.g., `get_route_for_model`) visible
+  in Nautobot core, not hard-coded strings.

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/AGENTS.md
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/AGENTS.md
@@ -22,7 +22,7 @@ this repository's tooling and style.
 - **ChatOps:** This app extends Nautobot ChatOps functionality with **worker
   functions**, **subcommands**, and **dispatcher patterns** for chat platform
   integration (Slack, Microsoft Teams, Webex, Mattermost).
-- **Python:** `>=3.10,<3.15`, as declared in `pyproject.toml`.
+- **Python:** `>=3.11,<3.15`, as declared in `pyproject.toml`.
 - **Dependency & venv:** **Poetry** only.
 - **Task runner:** `invoke` (always via Poetry).
 - **Style:** Ruff + Pylint; **imports at the top**; prefer **docstrings over
@@ -40,6 +40,7 @@ Always use Poetry for dependency management and virtualenvs.
   `poetry run invoke <task> [args]`
 
 Examples:
+
 - `poetry run invoke autoformat`
 - `poetry run invoke ruff`
 - `poetry run invoke pylint`
@@ -180,6 +181,7 @@ Nautobot provides **namespace classes** (`ViewTestCases`, `APIViewTestCases`, `F
 **How it works:** Inherit from a composite class (e.g., `ViewTestCases.PrimaryObjectViewTestCase`) and provide declarative data (`model`, `form_data`, `csv_data`, `bulk_edit_data`) in `setUpTestData`. The framework generates and runs all relevant test methods automatically.
 
 **Works well with:**
+
 - Standard CRUD operations using `NautobotUIViewSet` / `NautobotModelViewSet`
 - Consistent permission testing (403/302 without, 200 with)
 - API contract testing (serializer validation, depth params, bulk ops)
@@ -187,6 +189,7 @@ Nautobot provides **namespace classes** (`ViewTestCases`, `APIViewTestCases`, `F
 - Performance regression testing (`assertApproximateNumQueries`)
 
 **Does not cover:**
+
 - Highly custom views (wizards, multi-step forms, non-CRUD actions)
 - Custom DRF `@action` endpoints beyond standard CRUD
 - Non-model-backed views (dashboards, reports)
@@ -342,6 +345,7 @@ Options:
   jobs.
 
 **Common recipes**  
+
 - Run with coverage:  
   `poetry run invoke unittest --coverage`
 - Target a specific module (label):  
@@ -368,6 +372,7 @@ ChatOps apps follow a **three-layer architecture**: input (views/sockets) → wo
 → output (dispatchers).
 
 **Worker module organization:**
+
 - Main worker function in `worker.py` using `handle_subcommands()`
 - Subcommands using `@subcommand_of()` decorator
 - Each subcommand function takes `dispatcher` as first argument
@@ -397,6 +402,7 @@ def get_device_info(dispatcher, device_name):
 **Required signature:** `def subcommand_func(dispatcher, arg1, arg2=None, ...):`
 
 **Return values:**
+
 - `return False` - Command incomplete (prompting user), don't log
 - `return True` - Command succeeded
 - `return CommandStatusChoices.STATUS_SUCCEEDED` - Command succeeded
@@ -416,6 +422,7 @@ dispatcher.prompt_for_text(action_id=action, help_text="Enter number", label="Li
 platform-specific APIs directly.
 
 **Common dispatcher methods:**
+
 - `dispatcher.send_markdown(text)` - Simple markdown message
 - `dispatcher.send_blocks(blocks)` - Rich formatted blocks
 - `dispatcher.send_large_table(headers, *rows)` - Table data
@@ -464,10 +471,12 @@ def get_device_info(dispatcher, site_name=None, device_name=None):
 ### 8.5 Platform Considerations & Output Formatting
 
 **Text limits:** Different platforms have different limits:
+
 - Slack: ~4000 characters for messages, ~3000 for blocks
 - Microsoft Teams: ~69 character line wrapping, no preformatted text in cards
 
 **Responsive design:**
+
 - Use `send_large_table()` for data that might exceed platform limits
 - Use `send_blocks()` for rich formatting when possible
 - Fall back to `send_markdown()` for simple text
@@ -810,6 +819,7 @@ job/celery conventions, and UI Component Framework examples.
   https://github.com/nautobot/nautobot-app-bgp-models
 
 **Guidance for agents**
+
 - Prefer examples from these repos over generic Django code.
 - Mirror **base class** usage (`PrimaryModel`, `NautobotModelViewSet`,
   `NautobotUIViewSet`, etc.).

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/AGENTS.md
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/AGENTS.md
@@ -22,7 +22,7 @@ this repository's tooling and style.
 - **ChatOps:** This app extends Nautobot ChatOps functionality with **worker
   functions**, **subcommands**, and **dispatcher patterns** for chat platform
   integration (Slack, Microsoft Teams, Webex, Mattermost).
-- **Python:** `>=3.11,<3.15`, as declared in `pyproject.toml`.
+- **Python:** `>=3.10,<3.15`, as declared in `pyproject.toml`.
 - **Dependency & venv:** **Poetry** only.
 - **Task runner:** `invoke` (always via Poetry).
 - **Style:** Ruff + Pylint; **imports at the top**; prefer **docstrings over

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/CLAUDE.md
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/CLAUDE.md
@@ -1,0 +1,1 @@
+../../nautobot-app/{{ cookiecutter.project_slug }}/CLAUDE.md

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/CONTRIBUTING.md
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../../nautobot-app/{{ cookiecutter.project_slug }}/CONTRIBUTING.md

--- a/nautobot-app-chatops/{{ cookiecutter.project_slug }}/GEMINI.md
+++ b/nautobot-app-chatops/{{ cookiecutter.project_slug }}/GEMINI.md
@@ -1,0 +1,1 @@
+../../nautobot-app/{{ cookiecutter.project_slug }}/GEMINI.md

--- a/nautobot-app-ssot/tests/test_bake_nautobot_app_ssot.py
+++ b/nautobot-app-ssot/tests/test_bake_nautobot_app_ssot.py
@@ -16,6 +16,12 @@ def test_bake_project(cookies):
     assert "pyproject.toml" in found_toplevel_files
     assert "README.md" in found_toplevel_files
     assert "LICENSE" in found_toplevel_files
+    assert "CONTRIBUTING.md" in found_toplevel_files
+    assert "AGENTS.md" in found_toplevel_files
+    assert "CLAUDE.md" in found_toplevel_files
+    assert "GEMINI.md" in found_toplevel_files
+    assert ".cursorrules" in found_toplevel_files
+    assert (result.project_path / ".github" / "copilot-instructions.md").is_file()
 
 
 def test_bake_nautobot_execution(cookies_baked_nautobot_app_ssot):

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/.cursorrules
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/.cursorrules
@@ -1,0 +1,1 @@
+../../nautobot-app/{{ cookiecutter.project_slug }}/.cursorrules

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/.github/copilot-instructions.md
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../../../nautobot-app/{{ cookiecutter.project_slug }}/.github/copilot-instructions.md

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/AGENTS.md
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/AGENTS.md
@@ -18,7 +18,7 @@ this repository's tooling and style.
 
 - **Stack:** Django app that runs inside **Nautobot** (network SoT & automation). Uses Postgres, Redis, and Celery via Nautobot. Prefer idiomatic **Django** and **Nautobot helper APIs**.
 - **SSOT Framework:** Built on **DiffSync** library for data synchronization. Uses `nautobot_ssot.contrib` classes for Nautobot integration patterns.
-- **Python:** `>=3.10,<3.15`, as declared in `pyproject.toml`.
+- **Python:** `>=3.11,<3.15`, as declared in `pyproject.toml`.
 - **Dependency & venv:** **Poetry** only.
 - **Task runner:** `invoke` (always via Poetry).
 - **Style:** Ruff + Pylint; **imports at the top**; prefer **docstrings over inline comments**; clear, explicit code.
@@ -35,6 +35,7 @@ Always use Poetry for dependency management and virtualenvs.
   `poetry run invoke <task> [args]`
 
 Examples:
+
 - `poetry run invoke autoformat`
 - `poetry run invoke ruff`
 - `poetry run invoke pylint`
@@ -154,6 +155,7 @@ Nautobot provides **namespace classes** (`ViewTestCases`, `APIViewTestCases`, `F
 **How it works:** Inherit from a composite class (e.g., `ViewTestCases.PrimaryObjectViewTestCase`) and provide declarative data (`model`, `form_data`, `csv_data`, `bulk_edit_data`) in `setUpTestData`. The framework generates and runs all relevant test methods automatically.
 
 **Works well with:**
+
 - Standard CRUD operations using `NautobotUIViewSet` / `NautobotModelViewSet`
 - Consistent permission testing (403/302 without, 200 with)
 - API contract testing (serializer validation, depth params, bulk ops)
@@ -161,6 +163,7 @@ Nautobot provides **namespace classes** (`ViewTestCases`, `APIViewTestCases`, `F
 - Performance regression testing (`assertApproximateNumQueries`)
 
 **Does not cover:**
+
 - Highly custom views (wizards, multi-step forms, non-CRUD actions)
 - Custom DRF `@action` endpoints beyond standard CRUD
 - Non-model-backed views (dashboards, reports)
@@ -300,10 +303,12 @@ Options:
 ```
 
 **When to use which**  
+
 - Use `poetry run invoke tests` for the full testing suite experience (ruff, yamllint, markdownlint, check_migrations, pylint, build_and_check_docs, validate_app_config, unittest, unitttest_coverage, coverage_lcov).  
 - Use `poetry run invoke unittest` for Django/unittest-native selection (labels/patterns), quick targeted runs, or parity with Nautobot core's CI jobs.
 
 **Common recipes**  
+
 - Run with coverage:  
   `poetry run invoke unittest --coverage`
 - Target a specific module (label):  
@@ -353,6 +358,7 @@ class VLANModel(NautobotModel):
 ```
 
 **Key Rules:**
+
 - Model fields must match Nautobot model fields exactly
 - Use `_identifiers` for unique identification (natural keys)
 - Use `_attributes` for data that can change
@@ -664,8 +670,6 @@ class DeviceNoteUIViewSet(NautobotUIViewSet):
     form_class = DeviceNoteForm
 ```
 
-```
-
 **DiffSync Model (SSOT)**
 ```python
 """DiffSync model for Device synchronization."""
@@ -756,6 +760,7 @@ Use them for import paths, base-class usage, testing mixins, viewset patterns, j
 - **Nautobot App — BGP Models:** https://github.com/nautobot/nautobot-app-bgp-models
 
 **Guidance for agents**  
+
 - Prefer examples from these repos over generic Django code.  
 - Mirror **base class** usage (`PrimaryModel`, `NautobotModelViewSet`, `NautobotUIViewSet`, etc.).  
 - Follow **testing** patterns under `nautobot/apps/testing` (mixins and tags) rather than ad‑hoc tests.  

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/AGENTS.md
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/AGENTS.md
@@ -1,0 +1,765 @@
+# Agent Instructions --- Nautobot SSoT App
+
+You are an AI coding agent working inside a **Nautobot SSoT App** repository. Your mission is
+to generate **small, readable, test-backed** changes. Follow **Nautobot
+patterns**, the **SSoT patterns** for DiffSync-based integrations, and
+this repository's tooling and style.
+
+> **Canonical file:** `AGENTS.md` is the single source of truth for AI agents in
+> this repository. `CLAUDE.md`, `GEMINI.md`, `.cursorrules` and
+> `.github/copilot-instructions.md` all point here. Update this file, not the
+> pointers.
+> **Scope:** You may add path-scoped GitHub Copilot rules via
+> `.github/instructions/*.instructions.md` if truly necessary.
+
+---
+
+## 0) Quick Facts (for Agents)
+
+- **Stack:** Django app that runs inside **Nautobot** (network SoT & automation). Uses Postgres, Redis, and Celery via Nautobot. Prefer idiomatic **Django** and **Nautobot helper APIs**.
+- **SSOT Framework:** Built on **DiffSync** library for data synchronization. Uses `nautobot_ssot.contrib` classes for Nautobot integration patterns.
+- **Python:** `>=3.10,<3.15`, as declared in `pyproject.toml`.
+- **Dependency & venv:** **Poetry** only.
+- **Task runner:** `invoke` (always via Poetry).
+- **Style:** Ruff + Pylint; **imports at the top**; prefer **docstrings over inline comments**; clear, explicit code.
+
+---
+
+## 1) Tooling & Environment (Poetry‑first)
+
+Always use Poetry for dependency management and virtualenvs.
+
+- Install deps:  
+  `poetry install`
+- **Run tasks (required):**  
+  `poetry run invoke <task> [args]`
+
+Examples:
+- `poetry run invoke autoformat`
+- `poetry run invoke ruff`
+- `poetry run invoke pylint`
+- `poetry run invoke tests`
+- `poetry run invoke check-migrations`
+- `poetry run invoke makemigrations -n <name>`
+- `poetry run invoke markdownlint`
+- `poetry run invoke yamllint`
+
+Prefer `invoke` tasks over ad‑hoc commands. **When suggesting commands, prefix them with `poetry run`.**
+
+---
+
+## 2) Style, Lint, and Documentation
+
+- **Ruff** is used for formatting and linting; **Pylint** for static analysis. Generated code must pass both.
+- **Imports:**  
+    - Place **all imports at the top** of the file (after the module docstring).  
+    - No wildcard imports; prefer absolute imports and explicit symbols.  
+    - Aliasing Nautobot app modules is fine for clarity, e.g.:  
+      `from nautobot.ipam import models as ipam_models`
+    - Prefer imports from `nautobot.apps` instead of `nautobot.core`
+- **Docstrings > inline comments:**  
+    - Keep inline comments to the minimum for non‑obvious logic.  
+    - Put purpose/params/returns/side‑effects in **module/class/function docstrings**.  
+- Write straightforward, readable code over clever one‑liners.
+- **Docs:**
+    - If you add/change features, update `docs/` accordingly.
+    - Use `mkdocs` syntax.
+    - Run `poetry run invoke markdownlint` to validate and resolve any issues with the markdown syntax.
+    - Run `poetry run invoke yamllint` to validate YAML files (e.g., mkdocs.yml).
+    - Run `poetry run invoke build-and-check-docs` to validate.
+
+---
+
+## 3) Use Nautobot’s Frameworks (default choices)
+
+When scaffolding features, use Nautobot’s base classes and helpers first:
+
+- **Models:** `PrimaryModel` (full Nautobot features) or `BaseModel` as appropriate.
+- **Forms:** `NautobotModelForm` (+ `NautobotBulkEditForm` for bulk edits, `NautobotFilterForm` for filter forms).
+- **FilterSets:** `NautobotModelFilterSet` (`Meta.fields = "__all__"` unless strongly justified).
+- **Serializers:** `NautobotModelSerializer` (writeable) / `BaseModelSerializer` (simple read‑only).
+- **API views:** `NautobotModelViewSet`.
+- **UI views:** `NautobotUIViewSet` (unifies list/detail/edit/delete).
+- **URLs/Routes:** Use helpers such as `get_route_for_model()`; do **not** hand‑craft route strings.
+
+**Why:** These reduce boilerplate, align with core Nautobot behavior, and improve maintainability.
+
+---
+
+## 4) Models & Data Layer
+
+- Prefer natural keys (e.g., unique `name`) or PKs; add `slug` only with clear rationale.
+- Use constant `CHARFIELD_MAX_LENGTH` for text lengths unless you have a very good reason not to.
+- Avoid `null=True` on strings; use empty string `""` when semantically empty.
+- For `ManyToManyField`, declare an explicit **through** model. We follow the convention of using both model names and the word Assignment for **through** models. Ex. `AccessPointDeviceAssignment`
+- If searchable, populate `searchable_models` on the `NautobotAppConfig` in the `__init__.py` file.
+
+---
+
+## 5) Forms, Filters, Templates, and UI Patterns
+
+- **Forms:**  
+    - Use `DynamicModelChoiceField` for large foreign keys.  
+    - Put complex validation in `clean()` (model or form as appropriate).
+- **Filters:**  
+    - Use `RelatedMembershipBooleanFilter` for boolean relationship filters (`has_*`).  
+    - Use `NaturalKeyOrPKMultipleChoiceFilter` for FK filters where applicable.
+    - Use `SearchFilter` for `q` parameter search logic.
+- **Templates (rare — prefer UI Component Framework):**
+    - **Prefer the UI Component Framework** for detail views unless strongly justified.
+    - When templates are necessary, extend Nautobot base templates; prefer provided filters (`|hyperlinked_object`, `|placeholder`, etc.) over `mark_safe`/hand‑rolled anchors.
+- **UI Patterns:**  
+    - Prefer **tabs** (via `NautobotUIViewSet`) for distinct data categories.  
+    - Use full‑width detail layouts for dense content.  
+    - Provide **stats tiles** / instance counts if helpful.  
+    - For long‑running actions, use **AJAX modal + polling** (Jobs/Celery).  
+    - Use inline edit sparingly and always re‑validate server‑side.
+
+---
+
+## 6) Migrations
+
+- **Do not generate migrations automatically.** Migration generation should be done by a developer, not by AI.
+- If models change, remind the developer to:
+    - `poetry run invoke check-migrations`
+    - `poetry run invoke makemigrations -n <meaningful_name>`
+- Keep schema and data migrations separate and reversible.
+- Use descriptive migration names (e.g., `devicenote_initial`, `provider_increase_account_length`).
+- Ruff‑format generated migrations for consistency.
+
+---
+
+## 7) Tests — What to Generate (Nautobot‑style, **required**)
+
+**Use Nautobot’s testing base classes and mixins. Don’t use `unittest.TestCase` or raw `django.test.TestCase`.**
+
+### 7.1 Test Types & Base Classes
+
+- **Unit tests:** inherit from `nautobot.apps.testing.TestCase` (auto‑tagged `unit`).
+- **View tests:** use `nautobot.apps.testing.ViewTestCases` mixins.
+- **API tests:** use `nautobot.apps.testing.APIViewTestCases` mixins  
+  (`CreateObjectViewTestCase`, `ListObjectsViewTestCase`, `GetObjectViewTestCase`,  
+  `UpdateObjectViewTestCase`, `DeleteObjectViewTestCase`, and bulk variants).  
+  These enforce `?brief=` behavior (declare `brief_fields`) and exercise bulk endpoints.
+- **Filter tests:** use `nautobot.apps.testing.FilterTestCases` (generic boolean/multi‑choice/tags tests).
+- **Form tests:** use `nautobot.core.testing.FormTestCases.BaseFormTestCase`.
+- **Integration (browser) tests:** `nautobot.apps.testing.SeleniumTestCase` (auto‑tagged `integration`).
+- **Migration tests:** `django_test_migrations.MigratorTestCase` (auto‑tagged `migration_test`).
+- **When to use `TransactionTestCase`:** Default to `TestCase` for all standard tests (models, views, filters, API) — it is faster because it uses transaction rollback. Use `TransactionTestCase` only when testing **Nautobot Jobs** end-to-end via `run_job_for_testing()`, because Jobs run through Celery and need real committed transactions visible across process boundaries. Note that `setUpTestData()` does **not** work with `TransactionTestCase`; create test data in `setUp()` or in individual test methods instead.
+
+### 7.2 Testing Mixin Strategy (`nautobot.apps.testing`)
+
+Nautobot provides **namespace classes** (`ViewTestCases`, `APIViewTestCases`, `FilterTestCases`) containing **inner test-case classes** that app developers compose via multiple inheritance. This pattern eliminates boilerplate by providing 30+ test methods (CRUD, permissions, bulk operations, pagination, query performance) from a single declarative class.
+
+**How it works:** Inherit from a composite class (e.g., `ViewTestCases.PrimaryObjectViewTestCase`) and provide declarative data (`model`, `form_data`, `csv_data`, `bulk_edit_data`) in `setUpTestData`. The framework generates and runs all relevant test methods automatically.
+
+**Works well with:**
+- Standard CRUD operations using `NautobotUIViewSet` / `NautobotModelViewSet`
+- Consistent permission testing (403/302 without, 200 with)
+- API contract testing (serializer validation, depth params, bulk ops)
+- Filter testing via `generic_filter_tests` declarations
+- Performance regression testing (`assertApproximateNumQueries`)
+
+**Does not cover:**
+- Highly custom views (wizards, multi-step forms, non-CRUD actions)
+- Custom DRF `@action` endpoints beyond standard CRUD
+- Non-model-backed views (dashboards, reports)
+- Complex form logic with conditional fields or JavaScript-dependent validation
+
+### 7.3 Directory Layout
+
+```
+<app>/tests/
+  test_models.py
+  test_filters.py
+  test_api.py
+  test_views.py
+  integration/
+    test_*.py
+  migration/
+    test_*.py
+```
+
+### 7.4 Running Tests
+
+- All tests (fast fixtures enabled):  
+
+**Help**
+```
+poetry run invoke tests
+```
+
+```
+Usage: inv[oke] [--core-opts] tests [--options] [other tasks here ...]
+
+Docstring:
+  Run all tests for this app.
+
+Options:
+  -f, --failfast    fail as soon as a single test fails don't run the entire test suite. (default:
+                    False)
+  -k, --keepdb      Save and re-use test database between test runs for faster re-testing. (default:
+                    False)
+  -l, --lint-only   Only run linters; unit tests will be excluded. (default: False)
+```
+
+### 7.5 Test Data & Fixtures
+
+- Prefer creating objects via model `.create()`/`.save()` inside tests.  
+- Avoid calling factories in `setUp()` / `setUpTestData()`; factory output can be stateful.  
+- Rely on cached/seeded fixtures where provided by the runner to keep tests fast and deterministic.
+
+### 7.6 API Test Skeleton (what the agent should scaffold)
+
+```python
+"""API tests for Widget."""
+from nautobot.apps.testing import APIViewTestCases
+from . import models
+
+class WidgetAPITests(
+    APIViewTestCases.CreateObjectViewTestCase,
+    APIViewTestCases.ListObjectsViewTestCase,
+    APIViewTestCases.GetObjectViewTestCase,
+    APIViewTestCases.UpdateObjectViewTestCase,
+    APIViewTestCases.DeleteObjectViewTestCase,
+):
+    """CRUD tests for the Widget REST API."""
+    model = models.Widget
+
+    # Returned keys for `?brief=true` (sorted)
+    brief_fields = ["display", "id", "name", "url"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.create_data = [
+            {"name": "Widget A"},
+            {"name": "Widget B"},
+        ]
+        cls.update_data = {"name": "Widget A+"}
+```
+
+### 7.7 Filter Test Skeleton
+
+```python
+"""Filter tests for Widget."""
+from nautobot.apps.testing import FilterTestCases
+from . import filters as widget_filters, models
+
+class WidgetFilterTests(FilterTestCases.FilterTestCase):
+    """Generic filter assertions for WidgetFilterSet."""
+    filterset = widget_filters.WidgetFilterSet
+    queryset = models.Widget.objects.all()
+
+    # Optional: map filter names to queryset kwargs to exercise generic cases.
+    generic_filter_tests = [
+        ["name", "name"],
+        # ["owner_id", "owner__id"],
+    ]
+```
+
+### 7.8 Views Test Skeleton
+
+```python
+"""View tests for Widget UI."""
+from nautobot.apps.testing import ViewTestCases
+from . import models
+
+class WidgetUIViewTests(ViewTestCases.PrimaryObjectViewTestCase):
+    """UI list/detail/create/edit/delete tests for Widget."""
+    model = models.Widget
+    bulk_edit_data = {"name": "Bulk Renamed"}
+```
+
+### 7.9 OpenAPI Schema Checks
+
+Nautobot's built-in test infrastructure includes OpenAPI schema validation. Ensure your app's serializers and endpoints remain schema-valid by running the full test suite (`poetry run invoke tests`). Do not generate custom OpenAPI schema tests — the framework handles this automatically.
+
+### 7.10 Unittest Task (Django/Nautobot runner)
+
+In addition to `invoke tests` (the default Nautobot test runner), this repo can use **Django’s unittest-style runner** via the `unittest` Invoke task when present. Prefer this when you want stock unittest selection semantics or when a plugin/app intends to mirror Nautobot core’s runner behavior.
+
+**Help**  
+```
+poetry run invoke unittest -h
+```
+```
+Usage: inv[oke] [--core-opts] unittest [--options] [other tasks here ...]
+
+Docstring:
+  Run Nautobot unit tests.
+
+Options:
+  -b, --[no-]buffer             Discard output from passing tests
+  -c, --coverage                Enable coverage reporting. Defaults to False
+  -f, --failfast                Fail fast on first failure
+  -k, --keepdb                  Re-use the test database between runs
+  -l STRING, --label=STRING     Directory or module label to test (runs subset)
+  -p STRING, --pattern=STRING   Select specific test methods/classes/modules
+  -s, --skip-docs-build         Skip building docs before tests
+  -v, --verbose                 Verbose test output
+```
+
+**When to use which**  
+- Use `poetry run invoke tests` for the full testing suite experience (ruff, yamllint, markdownlint, check_migrations, pylint, build_and_check_docs, validate_app_config, unittest, unitttest_coverage, coverage_lcov).  
+- Use `poetry run invoke unittest` for Django/unittest-native selection (labels/patterns), quick targeted runs, or parity with Nautobot core's CI jobs.
+
+**Common recipes**  
+- Run with coverage:  
+  `poetry run invoke unittest --coverage`
+- Target a specific module (label):  
+  `poetry run invoke unittest --label myapp.tests.test_api`
+- Match by pattern (method/class):  
+  `poetry run invoke unittest --pattern "WidgetAPITests and test_list_objects"`
+- Re-use the DB between runs for speed:  
+  `poetry run invoke unittest --keepdb`
+- Fail fast & suppress noise from passing tests:  
+  `poetry run invoke unittest --failfast --buffer`
+- Skip docs build if unchanged:  
+  `poetry run invoke unittest --skip-docs-build`
+
+> **Note:** Always prefix with `poetry run` to ensure tests execute inside the project’s Poetry environment.
+
+---
+
+## 8) SSOT Job Development Patterns
+
+This is a **Nautobot SSOT app** that enables data synchronization between Nautobot and external systems. Follow these SSOT-specific patterns:
+
+### 8.1 SSOT Job Architecture
+
+All SSOT jobs should inherit from either `DataSource` or `DataTarget` base classes from `nautobot_ssot.jobs`:
+
+- **DataSource:** Syncs data FROM external system TO Nautobot
+- **DataTarget:** Syncs data FROM Nautobot TO external system
+
+### 8.2 DiffSync Models
+
+Use `NautobotModel` from `nautobot_ssot.contrib` for automatic CRUD operations:
+
+```python
+from nautobot_ssot.contrib import NautobotModel
+from nautobot.ipam.models import VLAN
+
+class VLANModel(NautobotModel):
+    """DiffSync model for VLANs."""
+    _model = VLAN
+    _modelname = "vlan"
+    _identifiers = ("vid", "group__name")
+    _attributes = ("description",)
+
+    vid: int
+    group__name: Optional[str] = None
+    description: Optional[str] = None
+```
+
+**Key Rules:**
+- Model fields must match Nautobot model fields exactly
+- Use `_identifiers` for unique identification (natural keys)
+- Use `_attributes` for data that can change
+- Only normal fields, forward foreign keys, and custom fields in identifiers
+
+### 8.3 Adapter Patterns
+
+#### Nautobot Adapter
+Use `NautobotAdapter` from `nautobot_ssot.contrib` with automatic loading:
+
+```python
+from nautobot_ssot.contrib import NautobotAdapter
+
+class MySSoTNautobotAdapter(NautobotAdapter):
+    """DiffSync adapter for Nautobot."""
+    vlan = VLANModel
+    top_level = ("vlan",)
+    
+    # Optional: override parameter loading
+    def load_param_time_zone(self, parameter_name, database_object):
+        """Custom loader for time_zone parameter."""
+        return str(getattr(database_object, parameter_name))
+```
+
+#### Remote Adapter
+Implement `load()` method for external system data:
+
+```python
+from diffsync import Adapter
+
+class MySSoTRemoteAdapter(Adapter):
+    """DiffSync adapter for remote system."""
+    vlan = VLANModel
+    top_level = ("vlan",)
+
+    def __init__(self, *args, api_client, job=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.api_client = api_client
+        self.job = job
+
+    def load(self):
+        """Load data from remote system."""
+        for vlan in self.api_client.get_vlans():
+            loaded_vlan = self.vlan(
+                vid=vlan["vlan_id"], 
+                group__name=vlan["grouping"], 
+                description=vlan["description"]
+            )
+            self.add(loaded_vlan)
+```
+
+### 8.4 Job Implementation
+
+```python
+from nautobot_ssot.jobs import DataSource
+from nautobot.extras.jobs import Job
+
+class ExampleDataSource(DataSource, Job):
+    """SSoT Job class."""
+    
+    class Meta:
+        name = "Example Data Source"
+        description = "Sync VLANs from external system"
+
+    def load_source_adapter(self):
+        """Load the source (remote) adapter."""
+        self.source_adapter = MySSoTRemoteAdapter(
+            api_client=APIClient(), 
+            job=self
+        )
+        self.source_adapter.load()
+
+    def load_target_adapter(self):
+        """Load the target (Nautobot) adapter."""
+        self.target_adapter = MySSoTNautobotAdapter(job=self)
+        self.target_adapter.load()
+
+    # Optional: provide additional metadata
+    def lookup_object(self, model_name, unique_id):
+        """Provide object lookup for UI display."""
+        # Implementation for object lookup
+        pass
+
+    def data_mappings(self):
+        """Return data mapping information for UI."""
+        return [
+            {"source": "Remote System VLANs", "target": "Nautobot VLANs"}
+        ]
+
+jobs = [ExampleDataSource]
+```
+
+### 8.5 Many-to-Many Relationships
+
+For M2M and N:1 relationships, use TypedDict with SortKey annotation:
+
+```python
+from nautobot_ssot.contrib.typeddicts import SortKey
+from typing_extensions import Annotated, TypedDict
+
+class TagDict(TypedDict):
+    """Many-to-many relationship typed dict."""
+    name: Annotated[str, SortKey]
+    description: Optional[str] = ""
+```
+
+### 8.6 SSOT Testing Patterns
+
+Test SSOT jobs with DiffSync-specific test cases:
+
+```python
+from nautobot.apps.testing import TestCase
+from nautobot_ssot.tests.utils import SSOTTestCase
+
+class TestMySSoTJob(SSOTTestCase):
+    """Test SSOT job functionality."""
+    
+    def test_data_sync(self):
+        """Test data synchronization."""
+        # Test adapter loading
+        # Test diff calculation  
+        # Test sync execution
+        pass
+```
+
+### 8.7 SSOT Best Practices
+
+- **Performance:** Use bulk operations in adapters when possible
+- **Error Handling:** Implement proper exception handling in load methods
+- **Logging:** Use job.logger for consistent logging
+- **Dry Run:** Always support dry-run mode for testing
+- **Device Types:** Handle Interface creation conflicts with Device Types
+- **Relationships:** Sort M2M relationships consistently using SortKey
+- **Validation:** Validate data in adapters before adding to DiffSync
+- **Dependencies:** Load parent objects before children in hierarchical data
+
+## 9) Celery & Jobs
+
+- For long‑running work or external calls, prefer **Celery tasks** or **Nautobot Jobs**.  
+- Do **not** block web requests with heavy processing.
+
+---
+
+## 10) Security & Secrets
+
+- Never hard‑code secrets/tokens/credentials.  
+- Use Nautobot Secrets / External Integrations.  
+- Scrub PII and sensitive network details from examples/tests.
+
+---
+
+## 11) Performance & DB
+
+- Prefer queryset filters/bulk ops over per‑row loops.  
+- Use `select_related` / `prefetch_related` where appropriate.  
+- Add indexes for frequently filtered fields; justify in migration message.
+
+---
+
+## 12) Git & Branching
+
+- Small, focused branches.  
+- PRs must include tests, migration notes (if any), and "how to test" steps.  
+- Reference related issues.  
+- Target the `develop` branch for PRs (not `main`, which is reserved for releases).
+
+---
+
+## 13) PR Hygiene — What the Agent Should Suggest
+
+- Clear, action‑oriented title and description.  
+- Link to issue(s) and include screenshots/GIFs for UI work.  
+- Call out any migrations and potential data impacts.  
+- Keep the diff small and logically cohesive.
+- Add a changelog fragment at `changes/<issue>.<type>`. Valid types are `added`,
+  `changed`, `deprecated`, `fixed`, `removed`, and `security`. Write one complete
+  sentence in past tense, starting with a capital letter and ending with a period.
+- Tick the AI-assistance disclosure item in the pull request template, and name the
+  provider and model you used.
+
+### Maintainer Expectations for AI Contributions
+
+Maintainers accept AI-assisted contributions under these conditions.
+
+- A human author owns the change. That author understands every line and answers
+  review questions without further generation.
+- The author runs `poetry run invoke tests` locally, and the suite passes, before
+  the pull request opens.
+- The author discloses AI assistance in the pull request, with the provider and the
+  model. See `CONTRIBUTING.md`.
+- New behavior arrives with tests. A bug fix arrives with the regression test that
+  would have caught it.
+- Maintainers close large, unreviewed, machine-generated pull requests without a
+  detailed review.
+
+---
+
+## 14) Snippets the Agent Should Prefer
+
+**SSOT Job**
+```python
+"""SSOT Job for syncing external data."""
+from nautobot_ssot.jobs import DataSource
+from nautobot.extras.jobs import Job
+from nautobot_ssot.contrib import NautobotAdapter, NautobotModel
+from diffsync import Adapter
+
+class ExternalDataSource(DataSource, Job):
+    """Sync data from external system to Nautobot."""
+    
+    class Meta:
+        name = "External Data Sync"
+        description = "Synchronize data from external system"
+
+    def load_source_adapter(self):
+        """Load external system adapter."""
+        self.source_adapter = ExternalAdapter(job=self)
+        self.source_adapter.load()
+
+    def load_target_adapter(self):
+        """Load Nautobot adapter."""
+        self.target_adapter = MyNautobotAdapter(job=self)
+        self.target_adapter.load()
+
+jobs = [ExternalDataSource]
+```
+
+**Model**
+```python
+"""DeviceNote model."""
+from django.db import models
+from nautobot.apps.constants import CHARFIELD_MAX_LENGTH
+from nautobot.apps.models import PrimaryModel
+
+class DeviceNote(PrimaryModel):
+    """Freeform note attached to a device."""
+    name = models.CharField(max_length=CHARFIELD_MAX_LENGTH, unique=True)
+    content = models.TextField(blank=True, default="")
+    # Unless you have a really good reason not to, we should have a FK to Tenant.
+    tenant = models.ForeignKey(
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="device_notes",
+        blank=True,
+        null=True,
+    )
+    class Meta:
+        ordering = ("name",)
+
+    def __str__(self):
+        """Stringify instance."""
+        return self.name
+```
+
+**Serializer**
+```python
+"""Serializer for DeviceNote."""
+from nautobot.apps.api import NautobotModelSerializer, TaggedModelSerializerMixin
+from .models import DeviceNote
+
+class DeviceNoteSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
+    """Serialize DeviceNote objects."""
+    class Meta:
+        model = DeviceNote
+        fields = "__all__"
+```
+
+**FilterSet**
+```python
+"""FilterSet for DeviceNote."""
+from nautobot.apps.filters import NautobotFilterSet, TenancyModelFilterSetMixin
+from .models import DeviceNote
+
+class DeviceNoteFilter(TenancyModelFilterSetMixin, NautobotFilterSet):
+    """Filter DeviceNote by name/content."""
+    class Meta:
+        model = DeviceNote
+        fields = "__all__"
+```
+
+**API ViewSet**
+```python
+"""API viewset for DeviceNote."""
+from nautobot.apps.api import NautobotModelViewSet
+from .filters import DeviceNoteFilter
+from .serializers import DeviceNoteSerializer
+from .models import DeviceNote
+
+class DeviceNoteViewSet(NautobotModelViewSet):
+    """List, retrieve, and manage DeviceNotes via REST API."""
+    queryset = DeviceNote.objects.all()
+    serializer_class = DeviceNoteSerializer
+    filterset_class = DeviceNoteFilter
+```
+
+**UI ViewSet**
+```python
+"""UI viewset for DeviceNote."""
+from nautobot.apps.views import NautobotUIViewSet
+from .models import DeviceNote
+from .tables import DeviceNoteTable
+from .forms import DeviceNoteForm
+
+class DeviceNoteUIViewSet(NautobotUIViewSet):
+    """UI for listing, viewing, creating, and editing DeviceNotes."""
+    queryset = DeviceNote.objects.all()
+    table = DeviceNoteTable
+    bulk_update_form_class = DeviceNoteForm
+    form_class = DeviceNoteForm
+```
+
+```
+
+**DiffSync Model (SSOT)**
+```python
+"""DiffSync model for Device synchronization."""
+from typing import Optional
+from nautobot_ssot.contrib import NautobotModel
+from nautobot.dcim.models import Device
+
+class DeviceModel(NautobotModel):
+    """DiffSync model for Devices."""
+    _model = Device
+    _modelname = "device"
+    _identifiers = ("name", "location__name")
+    _attributes = ("serial", "device_type__model")
+
+    name: str
+    location__name: str
+    serial: Optional[str] = None
+    device_type__model: Optional[str] = None
+```
+
+**Remote Adapter (SSOT)**
+```python
+"""Remote adapter for external system."""
+from diffsync import Adapter
+from .models import DeviceModel
+
+class ExternalAdapter(Adapter):
+    """DiffSync adapter for external system."""
+    device = DeviceModel
+    top_level = ("device",)
+
+    def __init__(self, *args, job=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.job = job
+        # Initialize external system client here
+
+    def load(self):
+        """Load data from external system."""
+        devices = self.external_client.get_devices()
+        for device_data in devices:
+            device = self.device(
+                name=device_data["hostname"],
+                location__name=device_data["site"],
+                serial=device_data.get("serial_number"),
+                device_type__model=device_data.get("model"),
+            )
+            self.add(device)
+```
+
+**Migrations (command)**
+```
+poetry run invoke makemigrations -n devicenote_initial
+```
+
+---
+
+## 15) Optional: Folder‑Specific Instructions
+
+If needed, add `.github/instructions/*.instructions.md` with path‑scoped front‑matter to apply specialized guidance to certain subtrees (e.g., `docs/`, `nautobot_plugin_tooling/`). Keep rules minimal to avoid confusion.
+
+---
+
+## 16) Final Checklist (for every change)
+
+- [ ] Commands are shown as `poetry run invoke ...`  
+- [ ] Imports are at the top; docstrings explain intent/usage  
+- [ ] Nautobot base classes, viewsets, and helpers are used  
+- [ ] Tests cover models/filters/API/views with Nautobot base classes & mixins  
+- [ ] Migrations are checked/generated, named meaningfully, and reversible  
+- [ ] Querysets are optimized; indexes added if needed  
+- [ ] No secrets/PII in code, tests, or docs  
+- [ ] Ruff & Pylint clean
+- [ ] PR description includes “how to test” and references related issues
+
+---
+
+## 17) Authoritative Nautobot Repositories & Examples
+
+When proposing or generating **Nautobot-specific code**, prefer patterns proven in the official repositories below.  
+Use them for import paths, base-class usage, testing mixins, viewset patterns, job/celery conventions, and UI Component Framework examples.
+
+- **Nautobot Core:** https://github.com/nautobot/nautobot/
+- **Nautobot App — SSoT:** https://github.com/nautobot/nautobot-app-ssot
+- **Nautobot App — Nornir:** https://github.com/nautobot/nautobot-app-nornir
+- **Nautobot App — Golden Config:** https://github.com/nautobot/nautobot-app-golden-config
+- **Nautobot App — DNS Models:** https://github.com/nautobot/nautobot-app-dns-models
+- **Nautobot App — Firewall Models:** https://github.com/nautobot/nautobot-app-firewall-models
+- **Nautobot App — BGP Models:** https://github.com/nautobot/nautobot-app-bgp-models
+
+**Guidance for agents**  
+- Prefer examples from these repos over generic Django code.  
+- Mirror **base class** usage (`PrimaryModel`, `NautobotModelViewSet`, `NautobotUIViewSet`, etc.).  
+- Follow **testing** patterns under `nautobot/apps/testing` (mixins and tags) rather than ad‑hoc tests.  
+- Reuse **filter/serializer** patterns and import paths exactly as shown in the official code.  
+- Avoid Nautobot 1.x and 2.x-only patterns; target **Nautobot 3.x** APIs and the
+  UI Component Framework. See `pyproject.toml` for the supported version range.  
+- If proposing URLs, prefer helper utilities (e.g., `get_route_for_model`) visible in Nautobot core, not hard‑coded strings.

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/CLAUDE.md
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/CLAUDE.md
@@ -1,0 +1,1 @@
+../../nautobot-app/{{ cookiecutter.project_slug }}/CLAUDE.md

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/CONTRIBUTING.md
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../../nautobot-app/{{ cookiecutter.project_slug }}/CONTRIBUTING.md

--- a/nautobot-app-ssot/{{ cookiecutter.project_slug }}/GEMINI.md
+++ b/nautobot-app-ssot/{{ cookiecutter.project_slug }}/GEMINI.md
@@ -1,0 +1,1 @@
+../../nautobot-app/{{ cookiecutter.project_slug }}/GEMINI.md

--- a/nautobot-app/tests/test_bake_nautobot_app.py
+++ b/nautobot-app/tests/test_bake_nautobot_app.py
@@ -16,6 +16,12 @@ def test_bake_project(cookies):
     assert "pyproject.toml" in found_toplevel_files
     assert "README.md" in found_toplevel_files
     assert "LICENSE" in found_toplevel_files
+    assert "CONTRIBUTING.md" in found_toplevel_files
+    assert "AGENTS.md" in found_toplevel_files
+    assert "CLAUDE.md" in found_toplevel_files
+    assert "GEMINI.md" in found_toplevel_files
+    assert ".cursorrules" in found_toplevel_files
+    assert (result.project_path / ".github" / "copilot-instructions.md").is_file()
 
 
 def test_bake_nautobot_execution(cookies_baked_nautobot_app):

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.cursorrules
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.cursorrules
@@ -1,0 +1,14 @@
+# Cursor Rules
+
+AGENTS.md in the repository root is the single source of truth for AI agents in
+this repository. Read AGENTS.md before you make any change, and follow it exactly.
+
+Key points, all detailed in AGENTS.md:
+
+- Use Poetry for every command: `poetry run invoke <task>`.
+- Run `poetry run invoke tests` before you propose a change.
+- Import from `nautobot.apps.*`, not from `nautobot.core.*`.
+- Use the Nautobot UI Component Framework for detail views.
+- Do not generate migrations. Ask the developer to run `invoke makemigrations`.
+- Add a changelog fragment at `changes/<issue>.<type>`.
+- Disclose AI assistance in the pull request. See CONTRIBUTING.md.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/copilot-instructions.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/copilot-instructions.md
@@ -1,0 +1,7 @@
+# Copilot Repository Instructions
+
+`AGENTS.md` in the repository root is the single source of truth for AI agents in
+this repository. Read it before you make any change, and follow it exactly.
+
+Add path-scoped rules under `.github/instructions/*.instructions.md` only when a
+directory needs guidance that does not belong in `AGENTS.md`.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.github/pull_request_template.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.github/pull_request_template.md
@@ -32,3 +32,4 @@
 - [ ] Unit, Integration Tests
 - [ ] Documentation Updates (when adding/changing features)
 - [ ] Outline Remaining Work, Constraints from Design
+- [ ] Disclosed AI assistance, if any (provider and model, e.g. `Anthropic Claude Opus 4.5`)

--- a/nautobot-app/{{ cookiecutter.project_slug }}/.gitignore
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/.gitignore
@@ -316,18 +316,18 @@ public
 CLAUDE.local.md
 
 # OpenAI Codex CLI
-AGENTS.md
+# AGENTS.md is committed; it is this repository's canonical agent instruction file.
 AGENTS.override.md
 .codex/
 
 # Google Gemini CLI
-GEMINI.md
+# GEMINI.md is committed; it points to AGENTS.md.
 .gemini/
 .vertexai/
 
 # Cursor (Anysphere)
+# .cursorrules is committed; it points to AGENTS.md.
 .cursor/
-.cursorrules
 .cursorignore
 .cursorindexingignore
 

--- a/nautobot-app/{{ cookiecutter.project_slug }}/AGENTS.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/AGENTS.md
@@ -1,0 +1,691 @@
+# Agent Instructions --- Nautobot App
+
+You are an AI coding agent working inside a **Nautobot App** repository. Your mission is
+to generate **small, readable, test-backed** changes that follow **Nautobot
+patterns** and this repository's tooling and style.
+
+> **Canonical file:** `AGENTS.md` is the single source of truth for AI agents in
+> this repository. `CLAUDE.md`, `GEMINI.md`, `.cursorrules` and
+> `.github/copilot-instructions.md` all point here. Update this file, not the
+> pointers.
+> **Scope:** You may add path-scoped GitHub Copilot rules via
+> `.github/instructions/*.instructions.md` if truly necessary.
+
+---
+
+## 0) Quick Facts (for Agents)
+
+- **Stack:** Django app that runs inside **Nautobot** (network SoT & automation). Uses Postgres, Redis, and Celery via Nautobot. Prefer idiomatic **Django** and **Nautobot helper APIs**.
+- **Python:** `>=3.10,<3.15`, as declared in `pyproject.toml`.
+- **Dependency & venv:** **Poetry** only.
+- **Task runner:** `invoke` (always via Poetry).
+- **Style:** Ruff + Pylint; **imports at the top**; prefer **docstrings over inline comments**; clear, explicit code.
+
+---
+
+## 1) Tooling & Environment (Poetry‑first)
+
+Always use Poetry for dependency management and virtualenvs.
+
+- Install deps:
+  `poetry install`
+- **Run tasks (required):**
+  `poetry run invoke <task> [args]`
+
+Examples:
+- `poetry run invoke autoformat`
+- `poetry run invoke ruff`
+- `poetry run invoke pylint`
+- `poetry run invoke tests`
+- `poetry run invoke check-migrations`
+- `poetry run invoke makemigrations -n <name>`
+- `poetry run invoke markdownlint`
+- `poetry run invoke yamllint`
+
+Prefer `invoke` tasks over ad‑hoc commands. **When suggesting commands, prefix them with `poetry run`.**
+
+---
+
+## 2) Style, Lint, and Documentation
+
+- **Ruff** is used for formatting and linting; **Pylint** for static analysis. Generated code must pass both.
+- **Imports:**
+    - Place **all imports at the top** of the file (after the module docstring).
+    - No wildcard imports; prefer absolute imports and explicit symbols.
+    - Aliasing Nautobot app modules is fine for clarity, e.g.:
+      `from nautobot.ipam import models as ipam_models`
+    - Prefer imports from `nautobot.apps` instead of `nautobot.core`
+- **Docstrings > inline comments:**
+    - Keep inline comments to the minimum for non‑obvious logic.
+    - Put purpose/params/returns/side‑effects in **module/class/function docstrings**.
+- Write straightforward, readable code over clever one‑liners.
+- **Docs:**
+    - If you add/change features, update `docs/` accordingly.
+    - Use `mkdocs` syntax.
+    - Run `poetry run invoke markdownlint` to validate and resolve any issues with the markdown syntax.
+    - Run `poetry run invoke yamllint` to validate YAML files (e.g., mkdocs.yml).
+    - Run `poetry run invoke build-and-check-docs` to validate.
+
+---
+
+## 3) Use Nautobot's Frameworks (default choices)
+
+When scaffolding features, use Nautobot's base classes and helpers first:
+
+- **Models:** `PrimaryModel` (full Nautobot features) or `BaseModel` as appropriate.
+- **Forms:** `NautobotModelForm` (+ `NautobotBulkEditForm` for bulk edits, `NautobotFilterForm` for filter forms).
+- **FilterSets:** `NautobotModelFilterSet` (`Meta.fields = "__all__"` unless strongly justified).
+- **Serializers:** `NautobotModelSerializer` (writeable) / `BaseModelSerializer` (simple read‑only).
+- **API views:** `NautobotModelViewSet`.
+- **UI views:** `NautobotUIViewSet` (unifies list/detail/edit/delete).
+- **URLs/Routes:** Use helpers such as `get_route_for_model()`; do **not** hand‑craft route strings.
+
+**Why:** These reduce boilerplate, align with core Nautobot behavior, and improve maintainability.
+
+---
+
+## 4) Models & Data Layer
+
+- Prefer natural keys (e.g., unique `name`) or PKs; add `slug` only with clear rationale.
+- Use constant `CHARFIELD_MAX_LENGTH` for text lengths unless you have a very good reason not to.
+- Avoid `null=True` on strings; use empty string `""` when semantically empty.
+- For `ManyToManyField`, declare an explicit **through** model. We follow the convention of using both model names and the word Assignment for **through** models. Ex. `AccessPointDeviceAssignment`
+- If searchable, populate `searchable_models` on the `NautobotAppConfig` in the `__init__.py` file.
+
+---
+
+## 5) UI Component Framework for Detail Views (Preferred)
+
+**IMPORTANT:** When creating or modifying object detail views, **always prefer the UI Component Framework over custom templates** (introduced in Nautobot 2.4).
+
+### What is the UI Component Framework?
+
+The UI Component Framework is a Python-based, declarative system for building object detail views. Instead of writing HTML templates, you define your UI structure using Python classes like `ObjectDetailContent`, `Panel`, `Tab`, and `Button`.
+
+### Why Use the Component Framework?
+
+- ✅ **No template files needed** for standard detail views
+- ✅ **Declarative and maintainable** — all UI logic in Python
+- ✅ **Automatic standard tabs** — Advanced, Contacts, Metadata, etc. are provided automatically
+- ✅ **Built-in permission handling** — panels and buttons respect permissions automatically
+- ✅ **Type safety** — better IDE support and fewer runtime errors
+- ✅ **Consistency** — automatic adherence to Nautobot design patterns
+
+### When to Use Components vs. Templates
+
+✅ **Use Component Framework (default choice)**:
+- New detail views
+- Refactoring existing detail views
+- Standard object detail pages
+- Any `NautobotUIViewSet` implementation
+
+❌ **Use Templates (rare exceptions only)**:
+- Highly custom UI requiring complex HTML beyond component capabilities
+- Legacy views not yet migrated
+- Non-standard views where components don't fit
+
+### Core Component Types
+
+#### ObjectDetailContent
+The top-level container for a detail view. Configure panels, extra tabs, and extra buttons.
+
+```python
+from nautobot.apps.ui import ObjectDetailContent
+
+object_detail_content = ObjectDetailContent(
+    panels=[...],           # Panels for the main tab
+    extra_buttons=[...],    # Additional action buttons
+    extra_tabs=[...],       # Custom tabs beyond standard tabs
+)
+```
+
+#### Panel Types
+
+- **`ObjectFieldsPanel`** — Display model fields as key-value pairs (most common)
+- **`ObjectsTablePanel`** — Display related objects in a table
+- **`StatsPanel`** — Show statistics with links to filtered views
+- **`ObjectTextPanel`** — Render text fields (Markdown, JSON, YAML, code)
+- **`GroupedKeyValueTablePanel`** — Collapsible accordion groups of fields
+- **`DataTablePanel`** — Lightweight tables from raw dictionaries
+
+#### Button Types
+
+- **`Button`** — Single action button
+- **`DropdownButton`** — Button with nested child buttons as dropdown menu
+- **`ExtraDetailViewActionButton`** — Action buttons in the main actions dropdown
+
+#### Tab Types
+
+- **`Tab`** — Standard tab with panels (rendered in same page)
+- **`DistinctViewTab`** — Tab that links to a separate view/URL (for complex data). **Requires a corresponding `@action` method** on the ViewSet that returns `Response({})`.
+
+### Component Framework Best Practices
+
+1. **Use `ObjectFieldsPanel` with `fields="__all__"`** for simple field display (auto-excludes ManyToMany, `id`, `created`, `last_updated`, `comments`, `tags`)
+2. **Use `ObjectsTablePanel`** for related object collections (specify `table_class` and `table_filter`)
+3. **Leverage weight constants** for consistent ordering:
+   ```python
+   Tab.WEIGHT_MAIN_TAB = 100
+   Tab.WEIGHT_ADVANCED_TAB = 200
+   Panel.WEIGHT_COMMENTS_PANEL = 200
+   Panel.WEIGHT_TAGS_PANEL = 600
+   ```
+4. **Use `SectionChoices`** for layout positioning: `LEFT_HALF`, `RIGHT_HALF`, `FULL_WIDTH`
+5. **Optimize queries** in `ObjectsTablePanel` using `select_related_fields` and `prefetch_related_fields`
+6. **Custom rendering** can be achieved by subclassing panels and overriding `render_value()` or `get_data()`
+
+---
+
+## 6) Forms, Filters, and UI Patterns
+
+- **Forms:**
+    - Use `DynamicModelChoiceField` for large foreign keys.
+    - Put complex validation in `clean()` (model or form as appropriate).
+- **Filters:**
+    - Use `RelatedMembershipBooleanFilter` for boolean relationship filters (`has_*`).
+    - Use `NaturalKeyOrPKMultipleChoiceFilter` for FK filters where applicable.
+    - Use `SearchFilter` for `q` parameter search logic.
+- **Templates (when needed):**
+    - Extend Nautobot base templates; prefer provided filters (`|hyperlinked_object`, `|placeholder`, etc.) over `mark_safe`/hand‑rolled anchors.
+- **UI Patterns:**
+    - **Prefer Component Framework** for detail views (see Section 5).
+    - Use **tabs** (via `ObjectDetailContent` extra_tabs) for distinct data categories.
+    - Provide **stats tiles** / instance counts if helpful via `StatsPanel`.
+    - For long‑running actions, use **AJAX modal + polling** (Jobs/Celery).
+    - Use inline edit sparingly and always re‑validate server‑side.
+
+---
+
+## 7) Migrations
+
+- **Do not generate migrations automatically.** Migration generation should be done by a developer, not by AI.
+- If models change, remind the developer to:
+    - `poetry run invoke check-migrations`
+    - `poetry run invoke makemigrations -n <meaningful_name>`
+- Keep schema and data migrations separate and reversible.
+- Use descriptive migration names (e.g., `devicenote_initial`, `provider_increase_account_length`).
+- Ruff‑format generated migrations for consistency.
+
+---
+
+## 8) Tests — What to Generate (Nautobot‑style, **required**)
+
+**Use Nautobot's testing base classes and mixins. Don't use `unittest.TestCase` or raw `django.test.TestCase`.**
+
+### 8.1 Test Types & Base Classes
+
+- **Unit tests:** inherit from `nautobot.apps.testing.TestCase` (auto‑tagged `unit`).
+- **View tests:** use `nautobot.apps.testing.ViewTestCases` mixins.
+- **API tests:** use `nautobot.apps.testing.APIViewTestCases` mixins
+  (`CreateObjectViewTestCase`, `ListObjectsViewTestCase`, `GetObjectViewTestCase`,
+  `UpdateObjectViewTestCase`, `DeleteObjectViewTestCase`, and bulk variants).
+  These enforce `?brief=` behavior (declare `brief_fields`) and exercise bulk endpoints.
+- **Filter tests:** use `nautobot.apps.testing.FilterTestCases` (generic boolean/multi‑choice/tags tests).
+- **Form tests:** use `nautobot.core.testing.FormTestCases.BaseFormTestCase`.
+- **Integration (browser) tests:** `nautobot.apps.testing.SeleniumTestCase` (auto‑tagged `integration`).
+- **Migration tests:** `django_test_migrations.MigratorTestCase` (auto‑tagged `migration_test`).
+- **When to use `TransactionTestCase`:** Default to `TestCase` for all standard tests (models, views, filters, API) — it is faster because it uses transaction rollback. Use `TransactionTestCase` only when testing **Nautobot Jobs** end-to-end via `run_job_for_testing()`, because Jobs run through Celery and need real committed transactions visible across process boundaries. Note that `setUpTestData()` does **not** work with `TransactionTestCase`; create test data in `setUp()` or in individual test methods instead.
+
+### 8.2 Testing Mixin Strategy (`nautobot.apps.testing`)
+
+Nautobot provides **namespace classes** (`ViewTestCases`, `APIViewTestCases`, `FilterTestCases`) containing **inner test-case classes** that app developers compose via multiple inheritance. This pattern eliminates boilerplate by providing 30+ test methods (CRUD, permissions, bulk operations, pagination, query performance) from a single declarative class.
+
+**How it works:** Inherit from a composite class (e.g., `ViewTestCases.PrimaryObjectViewTestCase`) and provide declarative data (`model`, `form_data`, `csv_data`, `bulk_edit_data`) in `setUpTestData`. The framework generates and runs all relevant test methods automatically.
+
+**Works well with:**
+- Standard CRUD operations using `NautobotUIViewSet` / `NautobotModelViewSet`
+- Consistent permission testing (403/302 without, 200 with)
+- API contract testing (serializer validation, depth params, bulk ops)
+- Filter testing via `generic_filter_tests` declarations
+- Performance regression testing (`assertApproximateNumQueries`)
+
+**Does not cover:**
+- Highly custom views (wizards, multi-step forms, non-CRUD actions)
+- Custom DRF `@action` endpoints beyond standard CRUD
+- Non-model-backed views (dashboards, reports)
+- Complex form logic with conditional fields or JavaScript-dependent validation
+
+### 8.3 Directory Layout
+
+```
+<app>/tests/
+  test_models.py
+  test_filters.py
+  test_api.py
+  test_views.py
+  integration/
+    test_*.py
+  migration/
+    test_*.py
+```
+
+### 8.4 Running Tests
+
+- All tests (fast fixtures enabled):
+
+**Help**
+```
+poetry run invoke tests
+```
+
+```
+Usage: inv[oke] [--core-opts] tests [--options] [other tasks here ...]
+
+Docstring:
+  Run all tests for this app.
+
+Options:
+  -f, --failfast    fail as soon as a single test fails don't run the entire test suite. (default:
+                    False)
+  -k, --keepdb      Save and re-use test database between test runs for faster re-testing. (default:
+                    False)
+  -l, --lint-only   Only run linters; unit tests will be excluded. (default: False)
+```
+
+### 8.5 Test Data & Fixtures
+
+- Prefer creating objects via model `.create()`/`.save()` inside tests.
+- Avoid calling factories in `setUp()` / `setUpTestData()`; factory output can be stateful.
+- Rely on cached/seeded fixtures where provided by the runner to keep tests fast and deterministic.
+
+### 8.6 API Test Skeleton (what the agent should scaffold)
+
+```python
+"""API tests for Widget."""
+from nautobot.apps.testing import APIViewTestCases
+from . import models
+
+class WidgetAPITests(
+    APIViewTestCases.CreateObjectViewTestCase,
+    APIViewTestCases.ListObjectsViewTestCase,
+    APIViewTestCases.GetObjectViewTestCase,
+    APIViewTestCases.UpdateObjectViewTestCase,
+    APIViewTestCases.DeleteObjectViewTestCase,
+):
+    """CRUD tests for the Widget REST API."""
+    model = models.Widget
+
+    # Returned keys for `?brief=true` (sorted)
+    brief_fields = ["display", "id", "name", "url"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.create_data = [
+            {"name": "Widget A"},
+            {"name": "Widget B"},
+        ]
+        cls.update_data = {"name": "Widget A+"}
+```
+
+### 8.7 Filter Test Skeleton
+
+```python
+"""Filter tests for Widget."""
+from nautobot.apps.testing import FilterTestCases
+from . import filters as widget_filters, models
+
+class WidgetFilterTests(FilterTestCases.FilterTestCase):
+    """Generic filter assertions for WidgetFilterSet."""
+    filterset = widget_filters.WidgetFilterSet
+    queryset = models.Widget.objects.all()
+
+    # Optional: map filter names to queryset kwargs to exercise generic cases.
+    generic_filter_tests = [
+        ["name", "name"],
+        # ["owner_id", "owner__id"],
+    ]
+```
+
+### 8.8 Views Test Skeleton
+
+```python
+"""View tests for Widget UI."""
+from nautobot.apps.testing import ViewTestCases
+from . import models
+
+class WidgetUIViewTests(ViewTestCases.PrimaryObjectViewTestCase):
+    """UI list/detail/create/edit/delete tests for Widget."""
+    model = models.Widget
+    bulk_edit_data = {"name": "Bulk Renamed"}
+```
+
+### 8.9 OpenAPI Schema Checks
+
+Nautobot's built-in test infrastructure includes OpenAPI schema validation. Ensure your app's serializers and endpoints remain schema-valid by running the full test suite (`poetry run invoke tests`). Do not generate custom OpenAPI schema tests — the framework handles this automatically.
+
+### 8.10 Unittest Task (Django/Nautobot runner)
+
+In addition to `invoke tests` (the default Nautobot test runner), this repo can use **Django's unittest-style runner** via the `unittest` Invoke task when present. Prefer this when you want stock unittest selection semantics or when a plugin/app intends to mirror Nautobot core's runner behavior.
+
+**Help**
+```
+poetry run invoke unittest -h
+```
+```
+Usage: inv[oke] [--core-opts] unittest [--options] [other tasks here ...]
+
+Docstring:
+  Run Nautobot unit tests.
+
+Options:
+  -b, --[no-]buffer             Discard output from passing tests
+  -c, --coverage                Enable coverage reporting. Defaults to False
+  -f, --failfast                Fail fast on first failure
+  -k, --keepdb                  Re-use the test database between runs
+  -l STRING, --label=STRING     Directory or module label to test (runs subset)
+  -p STRING, --pattern=STRING   Select specific test methods/classes/modules
+  -s, --skip-docs-build         Skip building docs before tests
+  -v, --verbose                 Verbose test output
+```
+
+**When to use which**
+- Use `poetry run invoke tests` for the full testing suite experience (ruff, yamllint, markdownlint, check_migrations, pylint, build_and_check_docs, validate_app_config, unittest, unittest_coverage, coverage_lcov).
+- Use `poetry run invoke unittest` for Django/unittest-native selection (labels/patterns), quick targeted runs, or parity with Nautobot core's CI jobs.
+
+**Common recipes**
+- Run with coverage:
+  `poetry run invoke unittest --coverage`
+- Target a specific module (label):
+  `poetry run invoke unittest --label myapp.tests.test_api`
+- Match by pattern (method/class):
+  `poetry run invoke unittest --pattern "WidgetAPITests and test_list_objects"`
+- Re-use the DB between runs for speed:
+  `poetry run invoke unittest --keepdb`
+- Fail fast & suppress noise from passing tests:
+  `poetry run invoke unittest --failfast --buffer`
+- Skip docs build if unchanged:
+  `poetry run invoke unittest --skip-docs-build`
+
+> **Note:** Always prefix with `poetry run` to ensure tests execute inside the project's Poetry environment.
+
+---
+
+## 9) Celery & Jobs
+
+- For long‑running work or external calls, prefer **Celery tasks** or **Nautobot Jobs**.
+- Do **not** block web requests with heavy processing.
+
+---
+
+## 10) Security & Secrets
+
+- Never hard‑code secrets/tokens/credentials.
+- Use Nautobot Secrets / External Integrations.
+- Scrub PII and sensitive network details from examples/tests.
+
+---
+
+## 11) Performance & DB
+
+- Prefer queryset filters/bulk ops over per‑row loops.
+- Use `select_related` / `prefetch_related` where appropriate.
+- Add indexes for frequently filtered fields; justify in migration message.
+
+---
+
+## 12) Git & Branching
+
+- Small, focused branches.
+- PRs must include tests, migration notes (if any), and "how to test" steps.
+- Reference related issues.
+- Target the `develop` branch for PRs (not `main`, which is reserved for releases).
+
+---
+
+## 13) PR Hygiene — What the Agent Should Suggest
+
+- Clear, action‑oriented title and description.
+- Link to issue(s) and include screenshots/GIFs for UI work.
+- Call out any migrations and potential data impacts.
+- Keep the diff small and logically cohesive.
+- Add a changelog fragment at `changes/<issue>.<type>`. Valid types are `added`,
+  `changed`, `deprecated`, `fixed`, `removed`, and `security`. Write one complete
+  sentence in past tense, starting with a capital letter and ending with a period.
+- Tick the AI-assistance disclosure item in the pull request template, and name the
+  provider and model you used.
+
+### Maintainer Expectations for AI Contributions
+
+Maintainers accept AI-assisted contributions under these conditions.
+
+- A human author owns the change. That author understands every line and answers
+  review questions without further generation.
+- The author runs `poetry run invoke tests` locally, and the suite passes, before
+  the pull request opens.
+- The author discloses AI assistance in the pull request, with the provider and the
+  model. See `CONTRIBUTING.md`.
+- New behavior arrives with tests. A bug fix arrives with the regression test that
+  would have caught it.
+- Maintainers close large, unreviewed, machine-generated pull requests without a
+  detailed review.
+
+---
+
+## 14) Snippets the Agent Should Prefer
+
+**Model**
+```python
+"""DeviceNote model."""
+from django.db import models
+from nautobot.apps.constants import CHARFIELD_MAX_LENGTH
+from nautobot.apps.models import PrimaryModel
+
+class DeviceNote(PrimaryModel):
+    """Freeform note attached to a device."""
+    name = models.CharField(max_length=CHARFIELD_MAX_LENGTH, unique=True)
+    content = models.TextField(blank=True, default="")
+    # Unless you have a really good reason not to, we should have a FK to Tenant.
+    tenant = models.ForeignKey(
+        to="tenancy.Tenant",
+        on_delete=models.PROTECT,
+        related_name="device_notes",
+        blank=True,
+        null=True,
+    )
+
+    class Meta:
+        ordering = ("name",)
+
+    def __str__(self):
+        """Stringify instance."""
+        return self.name
+```
+
+**Serializer**
+```python
+"""Serializer for DeviceNote."""
+from nautobot.apps.api import NautobotModelSerializer, TaggedModelSerializerMixin
+from .models import DeviceNote
+
+class DeviceNoteSerializer(NautobotModelSerializer, TaggedModelSerializerMixin):
+    """Serialize DeviceNote objects."""
+    class Meta:
+        model = DeviceNote
+        fields = "__all__"
+```
+
+**FilterSet**
+```python
+"""FilterSet for DeviceNote."""
+from nautobot.apps.filters import NautobotFilterSet, TenancyModelFilterSetMixin
+from .models import DeviceNote
+
+class DeviceNoteFilterSet(TenancyModelFilterSetMixin, NautobotFilterSet):
+    """Filter DeviceNote by name/content."""
+    class Meta:
+        model = DeviceNote
+        fields = "__all__"
+```
+
+**API ViewSet**
+```python
+"""API viewset for DeviceNote."""
+from nautobot.apps.api import NautobotModelViewSet
+from .filters import DeviceNoteFilterSet
+from .models import DeviceNote
+from .serializers import DeviceNoteSerializer
+
+class DeviceNoteViewSet(NautobotModelViewSet):
+    """List, retrieve, and manage DeviceNotes via REST API."""
+    queryset = DeviceNote.objects.all()
+    serializer_class = DeviceNoteSerializer
+    filterset_class = DeviceNoteFilterSet
+```
+
+**UI ViewSet (with Component Framework)**
+```python
+"""UI viewset for DeviceNote."""
+from nautobot.apps.ui import ObjectDetailContent, ObjectFieldsPanel, ObjectsTablePanel, SectionChoices
+from nautobot.apps.views import NautobotUIViewSet
+from .forms import DeviceNoteForm, DeviceNoteBulkEditForm
+from .models import DeviceNote
+from .tables import DeviceNoteTable
+
+class DeviceNoteUIViewSet(NautobotUIViewSet):
+    """UI for listing, viewing, creating, and editing DeviceNotes."""
+    queryset = DeviceNote.objects.all()
+    table_class = DeviceNoteTable
+    form_class = DeviceNoteForm
+    bulk_update_form_class = DeviceNoteBulkEditForm
+
+    object_detail_content = ObjectDetailContent(
+        panels=[
+            ObjectFieldsPanel(
+                weight=100,
+                section=SectionChoices.LEFT_HALF,
+                fields="__all__",
+            ),
+            # Optional: add related objects table
+            ObjectsTablePanel(
+                weight=200,
+                section=SectionChoices.RIGHT_HALF,
+                table_class=RelatedItemTable,
+                table_filter="device_note",
+                table_title="Related Items",
+            ),
+        ],
+    )
+```
+
+**Complex Detail View with Custom Panels and Tabs**
+```python
+"""Complex UI viewset example."""
+from nautobot.apps.ui import (
+    ObjectDetailContent,
+    ObjectFieldsPanel,
+    ObjectsTablePanel,
+    ObjectTextPanel,
+    StatsPanel,
+    SectionChoices,
+    Tab,
+    DistinctViewTab,
+)
+from nautobot.apps.views import NautobotUIViewSet
+from .models import ComplexModel, RelatedModel
+
+class ComplexModelUIViewSet(NautobotUIViewSet):
+    queryset = ComplexModel.objects.all()
+
+    object_detail_content = ObjectDetailContent(
+        panels=[
+            # Main tab panels
+            ObjectFieldsPanel(
+                weight=100,
+                section=SectionChoices.LEFT_HALF,
+                fields=["name", "status", "description"],
+            ),
+            StatsPanel(
+                weight=100,
+                section=SectionChoices.RIGHT_HALF,
+                filter_name="complex_model",
+                related_models=[RelatedModel],
+            ),
+            ObjectTextPanel(
+                weight=200,
+                section=SectionChoices.FULL_WIDTH,
+                label="Notes",
+                object_field="notes",
+                render_as=ObjectTextPanel.RenderOptions.MARKDOWN,
+            ),
+        ],
+        extra_tabs=[
+            # Custom tab with its own panels
+            Tab(
+                weight=Tab.WEIGHT_ADVANCED_TAB + 100,
+                tab_id="custom_data",
+                label="Custom Data",
+                panels=[
+                    ObjectsTablePanel(
+                        weight=100,
+                        table_class=CustomDataTable,
+                        table_attribute="custom_data_items",
+                    ),
+                ],
+            ),
+            # Distinct view tab (separate URL — requires @action method below)
+            DistinctViewTab(
+                weight=Tab.WEIGHT_CHANGELOG_TAB + 100,
+                tab_id="analytics",
+                label="Analytics",
+                url_name="myapp:complexmodel_analytics",
+                related_object_attribute="analytics_data",
+            ),
+        ],
+    )
+
+    # Each DistinctViewTab requires a corresponding @action method:
+    @action(detail=True, url_path="analytics", custom_view_base_action="view")
+    def analytics(self, request, *args, **kwargs):
+        return Response({})
+```
+
+**Migrations (command)**
+```
+poetry run invoke makemigrations -n devicenote_initial
+```
+
+---
+
+## 15) Optional: Folder‑Specific Instructions
+
+If needed, add `.github/instructions/*.instructions.md` with path‑scoped front‑matter to apply specialized guidance to certain subtrees (e.g., `docs/`, `nautobot_plugin_tooling/`). Keep rules minimal to avoid confusion.
+
+---
+
+## 16) Final Checklist (for every change)
+
+- [ ] Commands are shown as `poetry run invoke ...`
+- [ ] Imports are at the top; docstrings explain intent/usage
+- [ ] Nautobot base classes, viewsets, and helpers are used
+- [ ] **Detail views use Component Framework** (not custom templates unless necessary)
+- [ ] Tests cover models/filters/API/views with Nautobot base classes & mixins
+- [ ] Migrations are checked/generated, named meaningfully, and reversible
+- [ ] Querysets are optimized; indexes added if needed
+- [ ] No secrets/PII in code, tests, or docs
+- [ ] Ruff & Pylint clean
+- [ ] PR description includes "how to test" and references related issues
+
+---
+
+## 17) Authoritative Nautobot Repositories & Examples
+
+When proposing or generating **Nautobot-specific code**, prefer patterns proven in the official repositories below.
+Use them for import paths, base-class usage, testing mixins, viewset patterns, job/celery conventions, and **UI Component Framework** examples.
+
+- **Nautobot Core:** https://github.com/nautobot/nautobot/
+- **Nautobot App — SSoT:** https://github.com/nautobot/nautobot-app-ssot
+- **Nautobot App — Nornir:** https://github.com/nautobot/nautobot-app-nornir
+- **Nautobot App — Golden Config:** https://github.com/nautobot/nautobot-app-golden-config
+- **Nautobot App — DNS Models:** https://github.com/nautobot/nautobot-app-dns-models
+- **Nautobot App — Firewall Models:** https://github.com/nautobot/nautobot-app-firewall-models
+- **Nautobot App — BGP Models:** https://github.com/nautobot/nautobot-app-bgp-models
+
+**Guidance for agents**
+- Prefer examples from these repos over generic Django code.
+- Mirror **base class** usage (`PrimaryModel`, `NautobotModelViewSet`, `NautobotUIViewSet`, etc.).
+- Follow **testing** patterns under `nautobot/apps/testing` (mixins and tags) rather than ad‑hoc tests.
+- Reuse **filter/serializer** patterns and import paths exactly as shown in the official code.
+- **Use UI Component Framework** for detail views (see `nautobot/dcim/views.py`, `nautobot/vpn/views.py` for examples).
+- Avoid Nautobot 1.x and 2.x-only patterns; target **Nautobot 3.x** APIs and the
+  UI Component Framework. See `pyproject.toml` for the supported version range.
+- If proposing URLs, prefer helper utilities (e.g., `get_route_for_model`) visible in Nautobot core, not hard‑coded strings.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/AGENTS.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/AGENTS.md
@@ -16,7 +16,7 @@ patterns** and this repository's tooling and style.
 ## 0) Quick Facts (for Agents)
 
 - **Stack:** Django app that runs inside **Nautobot** (network SoT & automation). Uses Postgres, Redis, and Celery via Nautobot. Prefer idiomatic **Django** and **Nautobot helper APIs**.
-- **Python:** `>=3.10,<3.15`, as declared in `pyproject.toml`.
+- **Python:** `>=3.11,<3.15`, as declared in `pyproject.toml`.
 - **Dependency & venv:** **Poetry** only.
 - **Task runner:** `invoke` (always via Poetry).
 - **Style:** Ruff + Pylint; **imports at the top**; prefer **docstrings over inline comments**; clear, explicit code.
@@ -33,6 +33,7 @@ Always use Poetry for dependency management and virtualenvs.
   `poetry run invoke <task> [args]`
 
 Examples:
+
 - `poetry run invoke autoformat`
 - `poetry run invoke ruff`
 - `poetry run invoke pylint`
@@ -114,12 +115,14 @@ The UI Component Framework is a Python-based, declarative system for building ob
 ### When to Use Components vs. Templates
 
 ✅ **Use Component Framework (default choice)**:
+
 - New detail views
 - Refactoring existing detail views
 - Standard object detail pages
 - Any `NautobotUIViewSet` implementation
 
 ❌ **Use Templates (rare exceptions only)**:
+
 - Highly custom UI requiring complex HTML beyond component capabilities
 - Legacy views not yet migrated
 - Non-standard views where components don't fit
@@ -233,6 +236,7 @@ Nautobot provides **namespace classes** (`ViewTestCases`, `APIViewTestCases`, `F
 **How it works:** Inherit from a composite class (e.g., `ViewTestCases.PrimaryObjectViewTestCase`) and provide declarative data (`model`, `form_data`, `csv_data`, `bulk_edit_data`) in `setUpTestData`. The framework generates and runs all relevant test methods automatically.
 
 **Works well with:**
+
 - Standard CRUD operations using `NautobotUIViewSet` / `NautobotModelViewSet`
 - Consistent permission testing (403/302 without, 200 with)
 - API contract testing (serializer validation, depth params, bulk ops)
@@ -240,6 +244,7 @@ Nautobot provides **namespace classes** (`ViewTestCases`, `APIViewTestCases`, `F
 - Performance regression testing (`assertApproximateNumQueries`)
 
 **Does not cover:**
+
 - Highly custom views (wizards, multi-step forms, non-CRUD actions)
 - Custom DRF `@action` endpoints beyond standard CRUD
 - Non-model-backed views (dashboards, reports)
@@ -379,10 +384,12 @@ Options:
 ```
 
 **When to use which**
+
 - Use `poetry run invoke tests` for the full testing suite experience (ruff, yamllint, markdownlint, check_migrations, pylint, build_and_check_docs, validate_app_config, unittest, unittest_coverage, coverage_lcov).
 - Use `poetry run invoke unittest` for Django/unittest-native selection (labels/patterns), quick targeted runs, or parity with Nautobot core's CI jobs.
 
 **Common recipes**
+
 - Run with coverage:
   `poetry run invoke unittest --coverage`
 - Target a specific module (label):
@@ -681,6 +688,7 @@ Use them for import paths, base-class usage, testing mixins, viewset patterns, j
 - **Nautobot App — BGP Models:** https://github.com/nautobot/nautobot-app-bgp-models
 
 **Guidance for agents**
+
 - Prefer examples from these repos over generic Django code.
 - Mirror **base class** usage (`PrimaryModel`, `NautobotModelViewSet`, `NautobotUIViewSet`, etc.).
 - Follow **testing** patterns under `nautobot/apps/testing` (mixins and tags) rather than ad‑hoc tests.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/CLAUDE.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/CLAUDE.md
@@ -1,0 +1,6 @@
+# Claude Code Instructions
+
+`AGENTS.md` in the repository root is the single source of truth for AI agents in
+this repository. Read it before you make any change.
+
+@AGENTS.md

--- a/nautobot-app/{{ cookiecutter.project_slug }}/CONTRIBUTING.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to {{ cookiecutter.verbose_name }}
+
+Thank you for your interest in this project. The full guide is in the
+documentation, at [Contributing to the App]({{ cookiecutter.docs_app_url }}/dev/contributing/).
+This page is the short version, plus the policy on AI assistance.
+
+## Before You Open a Pull Request
+
+1. Open an issue, or comment on an existing one, so a maintainer can approve the work.
+2. Branch from `develop`. For a fix to a Nautobot LTM release, branch from the latest
+   `ltm-<major.minor>` branch instead.
+3. Add a changelog fragment at `changes/<issue>.<type>`. Valid types are `added`,
+   `changed`, `deprecated`, `fixed`, `removed`, and `security`.
+4. Add tests for new behavior. Add a regression test for a bug fix.
+5. Run the suite, and confirm that it passes:
+
+   ```shell
+   poetry run invoke tests
+   ```
+
+6. Open the pull request against `develop`, and complete the checklist in the template.
+
+## AI-Assisted Contributions
+
+This project accepts contributions written with the help of AI coding tools. The
+following conditions apply.
+
+- **A human owns the change.** You are the author. You understand every line you
+  submit, and you answer review questions yourself.
+- **You test the change.** Run `poetry run invoke tests` locally before you open the
+  pull request. Do not submit output you have not run.
+- **You disclose the assistance.** Tick the disclosure item in the pull request
+  template, and name the provider and the model, for example
+  `Anthropic Claude Opus 4.5` or `GitHub Copilot (GPT-5)`. Disclosure is not a
+  penalty; it helps reviewers calibrate their attention.
+- **You keep the change small.** Maintainers close large, unreviewed,
+  machine-generated pull requests without a detailed review.
+- **You follow the repository standards.** [`AGENTS.md`](AGENTS.md) states the design
+  patterns, the do's and don'ts, and the maintainer expectations for this repository.
+  Point your agent at that file.
+
+`AGENTS.md` is the canonical instruction file. `CLAUDE.md`, `GEMINI.md`,
+`.cursorrules`, and `.github/copilot-instructions.md` all point to it.

--- a/nautobot-app/{{ cookiecutter.project_slug }}/GEMINI.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/GEMINI.md
@@ -1,0 +1,6 @@
+# Gemini CLI Instructions
+
+`AGENTS.md` in the repository root is the single source of truth for AI agents in
+this repository. Read it before you make any change.
+
+@AGENTS.md

--- a/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/contributing.md
+++ b/nautobot-app/{{ cookiecutter.project_slug }}/docs/dev/contributing.md
@@ -70,6 +70,29 @@ If you are backporting any fixes to a prior major or minor version of this app, 
 
 We will create a `release-X.Y` branch for you to open your PR against and cut a new release once the PR is successfully merged.
 
+## AI-Assisted Contributions
+
+This project accepts contributions written with the help of AI coding tools. The
+following conditions apply.
+
+- **A human owns the change.** You are the author. You understand every line you
+  submit, and you answer review questions yourself.
+- **You test the change.** Run `invoke tests` locally before you open the pull
+  request. Do not submit output you have not run.
+- **You disclose the assistance.** Tick the disclosure item in the pull request
+  template, and name the provider and the model, for example
+  `Anthropic Claude Opus 4.5` or `GitHub Copilot (GPT-5)`. Disclosure is not a
+  penalty; it helps reviewers calibrate their attention.
+- **You keep the change small.** Maintainers close large, unreviewed,
+  machine-generated pull requests without a detailed review.
+- **You follow the repository standards.** `AGENTS.md` in the repository root states
+  the design patterns, the do's and don'ts, and the maintainer expectations for this
+  repository. Point your agent at that file.
+
+`AGENTS.md` is the canonical instruction file. `CLAUDE.md`, `GEMINI.md`,
+`.cursorrules`, and `.github/copilot-instructions.md` all point to it. Update
+`AGENTS.md`, not the pointers.
+
 ## Release Policy
 
 {{ cookiecutter.verbose_name }} has currently no intended scheduled release schedule, and will release new features in minor versions.


### PR DESCRIPTION
# Closes: #275

Implements NAPPS-1770, "AI Context and Contribution Standards to Open Source Apps".

## What's Changed

This promotes the reviewed content from the stale `copilot-instructions` branch
(#275, February 2026) into a canonical `AGENTS.md`, rather than writing new
instructions from scratch.

### Agent context files

The three open source templates — `nautobot-app`, `nautobot-app-chatops` and
`nautobot-app-ssot` — now ship the following.

| File | Form |
| --- | --- |
| `AGENTS.md` | Real per-template file (691 / 825 / 765 lines) |
| `CLAUDE.md` | Pointer to `AGENTS.md` |
| `GEMINI.md` | Pointer to `AGENTS.md` |
| `.cursorrules` | Pointer to `AGENTS.md` |
| `.github/copilot-instructions.md` | Pointer to `AGENTS.md` |

`AGENTS.md` is the single source of truth. The four pointers are real files in
`nautobot-app` and symlinks in the two overlays, matching the repository's
existing convention.

Edits applied to the promoted content:

- The wording is agent-neutral rather than Copilot-specific.
- The Python range is corrected to `>=3.10,<3.15`.
- The target is corrected from Nautobot 2.x to Nautobot 3.x.
- A new section, "Maintainer Expectations for AI Contributions", covers human
  ownership, local test runs, disclosure, changelog fragments, and the treatment
  of bulk machine-generated pull requests.
- Nested list indentation and trailing newlines now satisfy the linter.

### Contribution policy

- New root `CONTRIBUTING.md` in the three open source templates. GitHub shows a
  root `CONTRIBUTING.md` to a contributor who opens an issue or a pull request;
  a page under `docs/` is not shown. Generated apps previously had none.
- New "AI-Assisted Contributions" section in `docs/dev/contributing.md`.
- New AI-assistance disclosure item in the pull request template.

### Supporting changes

- Both `.gitignore` files stop ignoring `AGENTS.md`, `GEMINI.md` and
  `.cursorrules`. Without this the new files are silently dropped from every
  generated repository. The repository's own root patterns are anchored with a
  leading `/`, so the cookiecutter repo still ignores its own agent files while
  the templates can ship theirs.
- The three bake tests assert the new files.

## Two Points for the Reviewer

1. **`nautobot-app-commercial` receives the pull request checkbox and the
   `.gitignore` change.** Both files are symlinked by all four templates.
   Splitting them would create files that drift apart. The commercial template
   gets no `AGENTS.md` and no `CONTRIBUTING.md`, per the ticket scope.
2. **The disclosure is an optional checkbox**, not a required field and not a CI
   gate. Say so if you want it enforced.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [ ] Attached Screenshots, Payload Example — not applicable, documentation only
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design

## Verification

- `invoke ruff` passed. `invoke pylint` scored 10.00/10.
  `invoke build-and-check-docs` passed.
- `invoke unittest`: 8 passed, including the new assertions.
- Baked all four templates. The three open source apps contain all six files.
  The commercial app contains none.
- Ran `git add -A` inside a baked app. All six files stage, and
  `git check-ignore` reports none ignored.
- Markdown lint: the two rules this repository enables,
  `blanks-around-lists` and `list-anchored-indent`, reported 26 findings in the
  promoted content. All 26 are fixed. A baked app is now clean for both rules,
  which matches the `develop` baseline of zero.
- `towncrier check` found `changes/275.added`.

Note: `invoke markdownlint` fails locally with 305 findings, but it fails
identically on unmodified `origin/develop`. The local pymarkdown build ignores
`plugins.selectively_enable_rules`. This change adds no findings to that output.

## Remaining Work

Out of scope for this pull request, and worth separate tickets:

- No `AGENTS.md` for the `cookiecutter-nautobot-app` repository itself.
- `nautobot-app-commercial` still has no `docs/dev/contributing.md` at all.
- No CI enforcement of the disclosure checkbox.
